### PR TITLE
Fixed dropping bytes that happen to be value 0x0A

### DIFF
--- a/md380-gfx
+++ b/md380-gfx
@@ -250,7 +250,7 @@ class MD380Graphics(Memory):
         height = int(height)
         maxc = int(ppml[i+1])
         assert maxc == 255
-        data = ''.join(ppml[i+2:])
+        data = '\n'.join(ppml[i+2:])
         paletteidx = {}
         pixels = []
         palette = []


### PR DESCRIPTION
In md380-gfx, when parsing PPMs to convert back into sprites, sometimes it would try to index too far into the PPM data, even though everything seemed okay. Looking at it, realized it was splitting the ppm pixel data into "lines", indicating some bytes were `== 0x0A`, and hence the data was splitting there by accident, and then being rejoined without those bytes, leading to indexing past the end of the data.