### PR TITLE
Updated frequencies for chirp: Europe area

### DIFF
--- a/chirp/md380.py
+++ b/chirp/md380.py
@@ -330,7 +330,8 @@ class MD380Radio(chirp_common.CloneModeRadio):
         rf.can_odd_split = True
         rf.valid_tmodes = TMODES
         rf.memory_bounds = (1, 999)  # This radio supports memories 0-9
-        rf.valid_bands = [(400000000, 480000000),  # Supports 70-centimeters
+        #rf.valid_bands = [(400000000, 480000000),  # Supports 70-centimeters
+        rf.valid_bands = [(400000000, 480000000), (136000000, 174000000)  # Supports 70-centimeters
                           ]
         rf.valid_characters = "".join(CHARSET);
         rf.has_settings = True;


### PR DESCRIPTION
This adds a new frequency range for the chirp driver which worked for my MD-380, which has a frequency range from 136-174MHz