### PR TITLE
Better wording for ids that are not in users.csv

### DIFF
--- a/applet/src/dmr.c
+++ b/applet/src/dmr.c
@@ -93,7 +93,7 @@ void *dmr_call_start_hook(char *pkt){
   sprintf(DebugLine1, "%d -> %d", src, dst );
 
   if( find_dmr_user(DebugLine2, src, (void *) 0x100000, 80) == 0){
-    sprintf(DebugLine2, ",no users.csv,see md380-tool,usage");   // , is line seperator ;)
+    sprintf(DebugLine2, ",ID not found,in users.csv,see md380-tool");   // , is line seperator ;)
   }
 
   //This prints a dot at every resynchronization frame.


### PR DESCRIPTION
Sometimes (like TG 9998 Parrot for example) calls come in that are not
in the dmr-marc database. Other times new users arrive that aren't in
our loaded database yet. We shouldn't imply that the users.csv is not
loaded correctly. We should just state that the user isn't found in the
memory.