### PR TITLE
add a nix-shell environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+with import <nixpkgs> {}; {
+  md380toolsEnv = stdenv.mkDerivation {
+    name = "md380toolsEnv";
+    buildInputs = [
+      curl
+      gcc-arm-embedded
+      gnumake
+      libusb1
+      python27
+      python27Packages.pyusb
+      unzip
+    ];
+    LD_LIBRARY_PATH="${libusb1.out}/lib";
+  };
+}


### PR DESCRIPTION
if you use nixos or nix pkgs (like I do on debian/ubuntu), then you
can just type `nix-shell --pure` and drop into an automatically installed
pure environment with just the dependencies needed for this project in
your path.