### PR TITLE
run dos2unix on the md5 if under cygwin

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -8,6 +8,7 @@ clean:
 D002.032.bin: D002.032.zip
 	unzip --help >>/dev/null #Check that we have unzip
 	@unzip -p D002.032.zip 'Firmware 2.32/MD-380-D2.32(AD).bin' >D002.032.bin
+	dos2unix D002.032.bin.md5
 	@if md5sum -c D002.032.bin.md5 2>&1 > /dev/null; \
 	then echo "MD5 OK"; \
 	else \
@@ -18,6 +19,7 @@ D002.032.bin: D002.032.zip
 D002.032.zip:
 	curl --help >>/dev/null #Check that we have CURL.
 	curl 'http://www.va3xpr.net/?ddownload=9197' >D002.032.zip
+	dos2unix D002.032.zip.md5
 	@if md5sum -c D002.032.zip.md5 2>&1 > /dev/null; \
 	then echo "Download OK"; \
 	else \

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -8,7 +8,9 @@ clean:
 D002.032.bin: D002.032.zip
 	unzip --help >>/dev/null #Check that we have unzip
 	@unzip -p D002.032.zip 'Firmware 2.32/MD-380-D2.32(AD).bin' >D002.032.bin
-	dos2unix D002.032.bin.md5
+	ifeq ($(shell uname -o),Cygwin)
+		dos2unix D002.032.bin.md5
+	endif
 	@if md5sum -c D002.032.bin.md5 2>&1 > /dev/null; \
 	then echo "MD5 OK"; \
 	else \
@@ -19,7 +21,9 @@ D002.032.bin: D002.032.zip
 D002.032.zip:
 	curl --help >>/dev/null #Check that we have CURL.
 	curl 'http://www.va3xpr.net/?ddownload=9197' >D002.032.zip
-	dos2unix D002.032.zip.md5
+	ifeq ($(shell uname -o),Cygwin)
+		dos2unix D002.032.zip.md5
+	endif
 	@if md5sum -c D002.032.zip.md5 2>&1 > /dev/null; \
 	then echo "Download OK"; \
 	else \


### PR DESCRIPTION
fix for https://github.com/travisgoodspeed/md380tools/issues/85
now works on cygwin but untested on other OS's