### PR TITLE
Revert "run dos2unix on the md5 if under cygwin"

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -8,9 +8,6 @@ clean:
 D002.032.bin: D002.032.zip
 	unzip --help >>/dev/null #Check that we have unzip
 	@unzip -p D002.032.zip 'Firmware 2.32/MD-380-D2.32(AD).bin' >D002.032.bin
-	ifeq ($(shell uname -o),Cygwin)
-		dos2unix D002.032.bin.md5
-	endif
 	@if md5sum -c D002.032.bin.md5 2>&1 > /dev/null; \
 	then echo "MD5 OK"; \
 	else \
@@ -21,9 +18,6 @@ D002.032.bin: D002.032.zip
 D002.032.zip:
 	curl --help >>/dev/null #Check that we have CURL.
 	curl 'http://www.va3xpr.net/?ddownload=9197' >D002.032.zip
-	ifeq ($(shell uname -o),Cygwin)
-		dos2unix D002.032.zip.md5
-	endif
 	@if md5sum -c D002.032.zip.md5 2>&1 > /dev/null; \
 	then echo "Download OK"; \
 	else \


### PR DESCRIPTION
Reverts travisgoodspeed/md380tools#132.  It breaks on Unix.