### PR TITLE
removing artefacts of previous filled last line

### DIFF
--- a/applet/src/gfx.c
+++ b/applet/src/gfx.c
@@ -118,7 +118,7 @@ void print_DebugLine(unsigned int bg_color) {
       if (ii<29) buf[ii++]=DebugLine2[i];
       }
   }
-
+  drawascii2("                  ",10,102);
   drawascii2(DebugLine1, 10, 42);
   OSSemPost(debug_line_sem);
 


### PR DESCRIPTION
sometimes it happens that some text-info is left behind from previous or earlier overs in the last line. This cleans up the last line