### PR TITLE
First iteration of improved firmware downloader/unpacker makefile

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,29 +1,111 @@
 # This Makefile grabs firmware from the web, then decompresses it.
 
-# We used to check the MD5 hashes of each file, but this caused
-# portability issues and we're not too concerned about VA3XPR messing
-# with our firmware sources, so for now we just check filesize to
-# identify accidental corruption.  Anyone causing intentional
+# We used to download from VA3XPR, but since they started requiring
+# a newsletter subscription to access newer files, we have migrated
+# to using the Internet Archive.
+# Previously, we used to check the MD5 hashes of each file, but this
+# caused portability issues and we're not too concerned about VA3XPR
+# messing with our firmware sources, so for now we just check filesize
+# to identify accidental corruption.  Anyone causing intentional
 # corruption is politely asked to ensure that their joke is funny.
 
-all: D002.032.bin
+DLDIR = dl
+BINDIR = bin
+UNWRAPDIR = unwrapped
+
+DLFILES = $(DLDIR)/D002.022.zip $(DLDIR)/D002.025.zip $(DLDIR)/D002.026.zip $(DLDIR)/D002.030.zip $(DLDIR)/D002.032.zip $(DLDIR)/D002.034.zip $(DLDIR)/D003.008.zip $(DLDIR)/D013.009.bin
+BINARIES = $(addprefix $(BINDIR)/,$(patsubst %.zip,%.bin,$(notdir $(DLFILES))))
+UNWRAPPEDFILES = $(addprefix $(UNWRAPDIR)/,$(patsubst %.bin,%.img,$(notdir $(BINARIES))))
+
+.PHONY: all download binary unwrap clean cleanall
+
+all: download binary unwrap
+
+download: $(DLFILES)
+binary: $(BINARIES)
+unwrap: $(UNWRAPPEDFILES)
 
 clean:
-	rm -f *.zip *~ *.bin *.img
+	rm -rf $(BINDIR) $(UNWRAPDIR)
 
-D002.032.bin: D002.032.zip
-	unzip --help >>/dev/null #Check that we have unzip
-	unzip -p D002.032.zip 'Firmware 2.32/MD-380-D2.32(AD).bin' >D002.032.bin
-	du -k D002.032.bin | grep 972 || (rm D002.032.bin && false)
+cleanall: clean
+	rm -rf $(DLDIR)
 
-D002.032.zip:
-	curl --help >>/dev/null #Check that we have CURL.
-	curl 'http://www.va3xpr.net/?ddownload=9197' >D002.032.zip
-	du -k D002.032.zip | grep 2320 || (rm D002.032.zip && false)
+$(DLDIR):
+	mkdir -p $@
+$(BINDIR):
+	mkdir -p $@
+$(UNWRAPDIR):
+	mkdir -p $@
 
-D002.034.zip:
-	curl --help >>/dev/null #Check that we have CURL.
-	curl 'http://www.va3xpr.net/?ddownload=9420' >D002.034.zip
-D002.034.bin: D002.034.zip
-	unzip -p D002.034.zip MD-380-D2.34.bin >D002.034.bin
+$(UNWRAPDIR)/%.img: $(BINDIR)/%.bin $(UNWRAPDIR)
+	../md380-fw --unwrap $< $@
 
+$(BINDIR)/D002.022.bin: $(DLDIR)/D002.022.zip $(BINDIR)
+	which unzip >>/dev/null #Check that we have unzip
+	unzip -p $< 'TYT-MD-380-Firmware-Upgrade/Upgraded software for newest version.bin' >$@
+	du -k $@ | grep 980 || rm -f $@
+
+$(BINDIR)/D002.025.bin: $(DLDIR)/D002.025.zip $(BINDIR)
+	which unzip >>/dev/null #Check that we have unzip
+	unzip -p $< 'MD-380-D2/MD-380-D2.25.bin' >$@
+	du -k $@ | grep 972 || rm -f $@
+
+$(BINDIR)/D002.026.bin: $(DLDIR)/D002.026.zip $(BINDIR)
+	which unzip >>/dev/null #Check that we have unzip
+	unzip -p $< 'TYT-MD-380-Firmware-D002-2/MD-380-D2.26.bin' >$@
+	du -k $@ | grep 972 || rm -f $@
+
+$(BINDIR)/D002.030.bin: $(DLDIR)/D002.030.zip $(BINDIR)
+	which unzip >>/dev/null #Check that we have unzip
+	unzip -p $< 'MD-380-Firmware-v2/MD-380-D2.30.bin' >$@
+	du -k $@ | grep 972 || rm -f $@
+
+$(BINDIR)/D002.032.bin: $(DLDIR)/D002.032.zip $(BINDIR)
+	which unzip >>/dev/null #Check that we have unzip
+	unzip -p $< 'Firmware 2.32/MD-380-D2.32(AD).bin' >$@
+	du -k $@ | grep 972 || rm -f $@
+
+$(BINDIR)/D002.034.bin: $(DLDIR)/D002.034.zip $(BINDIR)
+	unzip -p $< 'TYT-MD380-FW-2-34/MD-380-D2.34.bin' >$@
+	du -k $@ | grep 972 || rm -f $@
+
+$(BINDIR)/D003.008.bin: $(DLDIR)/D003.008.zip $(BINDIR)
+	unzip -p $< 'D003.008.bin' >$@
+	du -k $@ | grep 976 || rm -f $@
+
+$(BINDIR)/D013.009.bin: $(DLDIR)/D013.009.bin $(BINDIR)
+	cp $< $@
+
+
+$(DLDIR)/D002.022.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/TYT-Tytera-MD-380-FW-v222.zip' >$@
+
+$(DLDIR)/D002.025.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/TYT-Tytera-MD-380-FW-v225.zip' >$@
+
+$(DLDIR)/D002.026.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/TYT-Tytera-MD-380-FW-v226.zip' >$@
+
+$(DLDIR)/D002.030.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/TYT-Tytera-MD-380-FW-v230.zip' >$@
+
+$(DLDIR)/D002.032.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/TYT-Tytera-MD-380-FW-v232.zip' >$@
+
+$(DLDIR)/D002.034.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/TYT-MD380-FW-2-34.zip' >$@
+
+$(DLDIR)/D003.008.zip: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/D003.008.zip' >$@
+
+$(DLDIR)/D013.009.bin: $(DLDIR)
+	which curl >>/dev/null #Check that we have curl.
+	curl -L 'https://archive.org/download/TYTMD380FW2/D013.009_tytera_walking_dead_firmware_by_ea8cwb.bin' >$@

--- a/patches/2.032/Makefile
+++ b/patches/2.032/Makefile
@@ -4,8 +4,8 @@ clean:
 	rm -f *~ *.bin *.img
 
 unwrapped.img:
-	cd ../../firmware && make D002.032.bin
-	../../md380-fw --unwrap ../../firmware/D002.032.bin unwrapped.img
+	cd ../../firmware && make unwrapped/D002.032.img
+	cp ../../firmware/unwrapped/D002.032.img $@
 
 patched.img: unwrapped.img
 	./patch.py


### PR DESCRIPTION
This updates the firmware downloader to
- download firmware images from archive.org, as VA3XPR has started requiring newsletter subscription
- download all versions of the firmware images
- unpack all versions of the firmware
- automatically unwrap all versions of the firmware
- only delete non-downloaded files during a normal "make clean", to prevent accidental loss of data

It also updates the 2.032 patcher to look in the new location for the firmware image.

A Phase 2 would provide a more generalized firmware download and unpack Makefile, probably pulling file information (locations, paths inside the zip, firmware checksums) from a text file listing this information.