### PR TITLE
moved promiscuous-eye a bit to the right

### DIFF
--- a/applet/src/gfx.c
+++ b/applet/src/gfx.c
@@ -131,6 +131,6 @@ void print_date_hook(void) {  // copy from the md380 code
 void print_ant_sym_hook(char *bmp, int x, int y) {
   gfx_drawbmp(bmp, x, y);
   if(global_addl_config.promtg==1) {
-    gfx_drawbmp((char *) &bmp_eye, 50, 1);
+    gfx_drawbmp((char *) &bmp_eye, 65, 1);
     }
   }


### PR DESCRIPTION
I think it looks better there because at pos. 50 it overlaps the muted-audio-display.
Maybe this is the SMS-letter-position, but I think, there are more users with muted audio-tones than users with unread sms :-)