### PR TITLE
Change Windows PATH variables for make

### DIFF
--- a/windows-instructions.txt
+++ b/windows-instructions.txt
@@ -8,7 +8,7 @@ In the C:\Python27 folder, make a copy of python.exe and name it python2.exe
 
 Add the following to your path variable
 (Right-click Start button -> System -> Advanced System Settings -> Environment Varables -> Select Path -> Edit):
-C:\Program Files\GnuWin32\bin
+C:\Progra~1\GnuWin32\bin    [use 'Progra~1' and NOT 'Program Files' otherwise make will fail]
 C:\Python27
 
 Download and install gcc-arm-none-eabi from: https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update

--- a/windows-instructions.txt
+++ b/windows-instructions.txt
@@ -32,7 +32,7 @@ Run Git (from start menu)
 Select 'Clone Existing Repository'
 
 Source: http://github.com/travisgoodspeed/md380tools
-Target: C:/Users/post2/Documents/git/travisgoodspeed/md380tools
+Target: C:/Users/<username>/Documents/git/travisgoodspeed/md380tools
 
 Once cloned:
 Find md380tools folder

--- a/windows-instructions.txt
+++ b/windows-instructions.txt
@@ -22,7 +22,7 @@ Type: python setup.py install
 
 Download and extract libusb-win32 from: https://sourceforge.net/projects/libusb-win32/
 Open the extracted folder and enter the bin folder
-Plug programming cable into usb port and radio. while holding top button & PTT, switch on radio
+Plug programming cable into USB port and radio. While holding top button & PTT, switch on radio
 run inf-wizard.exe -> Next
 select digital radio in USB mode -> Next -> Next
 Save the .inf file


### PR DESCRIPTION
To keep compatibility, spaces need to be removed from PATH variables for $(MAKE) to work