### PR TITLE
Add Reflector IDs from Brandmeister network to user DB

### DIFF
--- a/db/Makefile
+++ b/db/Makefile
@@ -7,7 +7,9 @@ clean:
 	rm -f users.csv repeaters.csv users.json repeaters.json
 
 users.csv:
-	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' | perl -pe 's,<br/>,,' >$@
+	curl -L -f 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@
+	perl -e 'print "\n5000,Status,,,,,,"' >>$@
+	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' | perl -pe 's,<br/>,,' >>$@
 users.json:
 	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=json&header=0' >$@
 repeaters.json:


### PR DESCRIPTION
This fetches the Reflector DB from the Brandmeister network and basically integrates the Reflector IDs into usres.csv. I used perl to parse the file in order to not break compatibility. 
As the file does not contain a newline at the end I manually added one together with ID 5000 which replies with a status info if sent out on a BM link.