### PR TITLE
Make menu item 'experimental' more clear

### DIFF
--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -35,7 +35,7 @@ const static wchar_t wt_promtg[]            = L"Promiscuous";
 const static wchar_t wt_edit[]              = L"Edit";
 const static wchar_t wt_edit_dmr_id[]       = L"Edit DMR-ID";
 const static wchar_t wt_no_w25q128[]        = L"No W25Q128";
-const static wchar_t wt_experimental[]      = L"Experimental";
+const static wchar_t wt_experimental[]      = L"Persist menu";
 const static wchar_t wt_micbargraph[]       = L"Mic bargraph";
 
 


### PR DESCRIPTION
This menu item only makes the menu persistent. Let's call it that.