### PR TITLE
Changed the blockfill 

### DIFF
--- a/applet/src/rtc_timer.c
+++ b/applet/src/rtc_timer.c
@@ -163,7 +163,7 @@ void print_rx_screen(unsigned int bg_color) {
 
   // clear screen
   gfx_set_fg_color(bg_color);
-  gfx_blockfill(0, 0, 200, 160);
+  gfx_blockfill(2, 16, 157, 130); // if we go any lower, we wrap around to the top
 
   gfx_set_bg_color(bg_color);
   gfx_set_fg_color(0x000000);
@@ -203,7 +203,7 @@ void print_rx_screen(unsigned int bg_color) {
       }
   }
 
-  sprintf(buf, "%d -> %d", src, dst );
+  sprintf(buf, "%d -> %d", src, dst ); // overwrite DMR id with source -> destination
   drawascii2(buf, 10, RX_POPUP_Y_START + 12);
 
   gfx_select_font((void *) MD380_FONT_NORM);


### PR DESCRIPTION
to leave the top bar free to integrate more seamless with the TX window.
This will show the top status bar again

Closes https://github.com/travisgoodspeed/md380tools/issues/309