### PR TITLE
Added: boot screen selection; radio name auto configuration; dynamic bootscreen

### DIFF
--- a/applet/src/addl_config.c
+++ b/applet/src/addl_config.c
@@ -23,8 +23,20 @@ void cfg_fix_dmrid()
     int dmrid = global_addl_config.dmrid ;
     if( dmrid != 0 ) {
         // store new dmr_id to ram and spi flash (codeplug)
-        md380_spiflash_write(&dmrid, 0x2084, 4);            
+        md380_spiflash_write(&dmrid, FLASH_OFFSET_DMRID, 4);
         md380_radio_config.dmrid = dmrid;
+    }
+}
+
+
+void cfg_fix_radioname()
+{
+    char *rname = global_addl_config.rname;
+    if( rname[0] != 0x00 ) {
+        md380_spiflash_write(&rname, FLASH_OFFSET_RNAME, 32);
+        for (uint8_t ii = 0; ii < 32; ii++) {
+            md380_radio_config.radioname[ii] = rname[ii];
+        }
     }
 }
 
@@ -80,11 +92,15 @@ void cfg_load()
     R(global_addl_config.debug,1);
     R(global_addl_config.rbeep,1);
     R(global_addl_config.promtg,1);
-    R(global_addl_config.netmon,1);
+    R(global_addl_config.bootscr,2);
+    R(global_addl_config.netmon,3);
     R(global_addl_config.datef,5);
-    
+
     // restore dmrid
     cfg_fix_dmrid();
+    
+    // restore radio name
+    cfg_fix_radioname();
             
     // global_addl_config.experimental is intentionally not permanent
     global_addl_config.experimental = 0;

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -7,6 +7,9 @@
 
 #include <stdint.h>
 
+#define FLASH_OFFSET_DMRID 0x2084
+#define FLASH_OFFSET_RNAME 0x20B0
+
 typedef struct addl_config {
     uint8_t crc;
     uint8_t length;
@@ -18,7 +21,9 @@ typedef struct addl_config {
     uint8_t micbargraph;
     uint8_t netmon;
     uint8_t rbeep;
-    uint32_t dmrid ;
+    uint8_t bootscr;
+    uint32_t dmrid;
+    char rname[32];
 } addl_config_t ;
 
 extern addl_config_t global_addl_config;
@@ -26,6 +31,7 @@ extern addl_config_t global_addl_config;
 extern void init_global_addl_config_hook(void);
 
 void cfg_fix_dmrid();
+void cfg_fix_radioname();
 
 void cfg_save();
 

--- a/applet/src/md380.h
+++ b/applet/src/md380.h
@@ -68,8 +68,9 @@ extern char dmr_squelch_mode[];
 extern char* const dmr_squelch_firstthing[];
 
 
-//Pointer to the buffer that stores the bottom line of screen text.
-extern char botlinetext[];
+//Pointer to the buffer that stores the top and bottom line of the boot screen text.
+extern char toplinetext[]; // [20] should be wchar_t[10]
+extern char botlinetext[]; // [20] should be wchar_t[10]
 
 //ROM copy of the welcome bitmap.
 extern char welcomebmp[];

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -21,6 +21,7 @@
 #include "spiflash.h"
 #include "addl_config.h"
 #include "radio_config.h"
+#include "usersdb.h"
 
 const static wchar_t wt_addl_func[]         = L"MD380Tools";
 const static wchar_t wt_datef[]             = L"Date format";
@@ -33,6 +34,10 @@ const static wchar_t wt_netmon[]            = L"DevOnly!!"; // for now, later a 
 const static wchar_t wt_disable[]           = L"Disable";
 const static wchar_t wt_enable[]            = L"Enable";
 const static wchar_t wt_rbeep[]             = L"M. RogerBeep";
+const static wchar_t wt_bootscr[]           = L"Boot Screen";
+const static wchar_t wt_bootscr_enable[]    = L"Enable";
+const static wchar_t wt_bootscr_quick[]     = L"Quick";
+const static wchar_t wt_bootscr_disable[]   = L"Disable";
 const static wchar_t wt_userscsv[]          = L"UsersCSV";
 const static wchar_t wt_datef_original[]    = L"YYYY/MM/DD";
 const static wchar_t wt_datef_germany[]     = L"DD.MM.YYYY";
@@ -383,6 +388,33 @@ void create_menu_entry_rbeep_disable_screen(void)
     cfg_save();
 }
 
+void create_menu_entry_bootscr_enable_screen(void)
+{
+    mn_create_single_timed_ack(wt_bootscr, wt_bootscr_enable);
+
+    global_addl_config.bootscr = 0;
+
+    cfg_save();
+}
+
+void create_menu_entry_bootscr_quick_screen(void)
+{
+    mn_create_single_timed_ack(wt_bootscr, wt_bootscr_quick);
+
+    global_addl_config.bootscr = 1;
+
+    cfg_save();
+}
+
+void create_menu_entry_bootscr_disable_screen(void)
+{
+    mn_create_single_timed_ack(wt_bootscr, wt_bootscr_disable);
+
+    global_addl_config.bootscr = 2;
+
+    cfg_save();
+}
+
 void create_menu_entry_datef_original_screen(void)
 {
     mn_create_single_timed_ack(wt_datef,wt_datef_original);
@@ -531,6 +563,19 @@ void create_menu_entry_rbeep_screen(void)
 
     mn_submenu_add(wt_enable, create_menu_entry_rbeep_enable_screen);
     mn_submenu_add(wt_disable, create_menu_entry_rbeep_disable_screen);
+
+    mn_submenu_finalize();
+}
+
+void create_menu_entry_bootscr_screen(void)
+{
+    mn_submenu_init(wt_bootscr);
+
+    md380_menu_entry_selected = global_addl_config.bootscr;
+
+    mn_submenu_add(wt_bootscr_enable, create_menu_entry_bootscr_enable_screen);
+    mn_submenu_add(wt_bootscr_quick, create_menu_entry_bootscr_quick_screen);
+    mn_submenu_add(wt_bootscr_disable, create_menu_entry_bootscr_disable_screen);
 
     mn_submenu_finalize();
 }
@@ -783,6 +828,57 @@ void create_menu_entry_edit_screen(void)
 #endif
 }
 
+void set_radio_name()
+{
+    uint8_t found = 0;
+    uint8_t pos = 0;
+    uint8_t b_size = 25;
+    char callsign[10];
+    char buf[b_size];
+    // Set the top line to the call sign found in the userdb
+    if ( find_dmr_user(buf, global_addl_config.dmrid, (void *) 0x100000, b_size) ) {
+        for (uint8_t i = 0; i < b_size; i++) {
+          if (buf[i] == 0) {
+              break;
+          }
+          if (buf[i] == ',') {
+              found++;
+          }
+          if (found > 0 && buf[i] != ',' && buf[i] != ' ') {
+              callsign[pos] = buf[i];
+              pos++;
+          }
+          if (found == 2 || pos >= 10) {
+              break;
+          }
+        }
+    }
+
+    if (pos == 0) {
+        strncpy(callsign, "UNKNOWNID", 10);
+    }
+
+    for (uint8_t ii = 0 ; ii < 20; ii++) {
+        toplinetext[ii] = 0x00;
+        if (ii%2 == 0) {
+            toplinetext[ii] = callsign[ii/2];
+        }
+    }
+
+    for (uint8_t ii = 0 ; ii < 32; ii++) {
+        if (ii%2 == 0 && ii < 20) {
+            md380_radio_config.radioname[ii] = callsign[ii/2];
+            global_addl_config.rname[ii] = callsign[ii/2];
+        } else {
+            md380_radio_config.radioname[ii] = 0x00;
+            global_addl_config.rname[ii] = 0x00;
+        }
+    }
+
+    cfg_save();
+    md380_spiflash_write(&md380_radio_config.radioname, FLASH_OFFSET_RNAME, 4);
+}
+
 void create_menu_entry_edit_dmr_id_screen_store(void)
 {
     uint32_t new_dmr_id = 0;
@@ -804,12 +900,15 @@ void create_menu_entry_edit_dmr_id_screen_store(void)
 #endif
     
     global_addl_config.dmrid = new_dmr_id ;
-    
     cfg_save();
+
     cfg_fix_dmrid();
 
     md380_menu_id = md380_menu_id - 1;
     md380_menu_depth = md380_menu_depth - 1;
+    
+    set_radio_name();
+
 #ifdef CONFIG_MENU
     md380_create_menu_entry(md380_menu_id, md380_menu_edit_buf, MKTHUMB(md380_menu_entry_back), MKTHUMB(md380_menu_entry_back), 6, 1, 1);
 #endif
@@ -908,6 +1007,7 @@ void create_menu_entry_addl_functions_screen(void)
 //#endif
 
     mn_submenu_add_98(wt_rbeep, create_menu_entry_rbeep_screen);
+    mn_submenu_add_98(wt_bootscr, create_menu_entry_bootscr_screen);
     mn_submenu_add_98(wt_datef, create_menu_entry_datef_screen);
     mn_submenu_add_98(wt_userscsv, create_menu_entry_userscsv_screen);
     mn_submenu_add_98(wt_debug, create_menu_entry_debug_screen);

--- a/applet/src/radio_config.h
+++ b/applet/src/radio_config.h
@@ -18,6 +18,8 @@ typedef struct {
     uint8_t backlight_time ;// [21] // times 5 seconds.
     uint8_t off22 ;         // [22]
     uint8_t mode_ch_mr ;    // [23] 255 = CH / 0 = MR
+    uint8_t unk4[48-23-1];
+    char radioname[32];     // [48]
     // [156] led ind?
 } radio_config_t ;
 

--- a/applet/src/symbols_d02.032
+++ b/applet/src/symbols_d02.032
@@ -4,8 +4,8 @@
 /* port to other versions.  Good candidates have long prologues. */
 
 /* Startup routines, very handy for hooking our startup. */
-startup_topline = 0x08021883;
-startup_botline = 0x08021895;
+toplinetext = 0x08021883;
+botlinetext = 0x08021895;
 
 /* Graphics functions. */
 gfx_drawtext                           = 0x800D88B;

--- a/applet/src/symbols_d13.020
+++ b/applet/src/symbols_d13.020
@@ -13,6 +13,7 @@ gfx_blockfill        = 0x0801d88d;
 gfx_set_bg_color     = 0x0801d369;
 gfx_set_fg_color     = 0x0801d371;
 
+toplinetext          = 0x2001e3fc;
 botlinetext          = 0x2001e410;
 welcomebmp           = 0x080f8510;
 

--- a/applet/src/symbols_s13.020
+++ b/applet/src/symbols_s13.020
@@ -13,6 +13,7 @@ gfx_blockfill        = 0x0801d9c1; /*  200 byte match */
 gfx_set_bg_color     = 0x0801d49d; /*  0x0800df26 */
 gfx_set_fg_color     = 0x0801d4a5; /*  0x0800df20 */
 
+toplinetext          = 0x2001e4cc; /* 0x080229b6 Get_Welcome_Line1_from_spi_flash */
 botlinetext          = 0x2001e4e0; /* 0x080229b6 Get_Welcome_Line2_from_spi_flash */
 welcomebmp           = 0x080f93d0; /* 0x080474f8 10 byte match */
 


### PR DESCRIPTION
This is three related additions packed into one.

First and foremost: the radio name is now set in the config from an automatic lookup in the usersdb whenever the DMR ID is changed. This means that peeps should be able to pass around codeplugs and never have to open them in a CPS. This change is set in memory, in the config, and in the codeplug flash on changes, and restored at boot just like the dmrid.

Secondly: The top and bottom lines of the stock text splash are now automatically populated with the DMR ID and the Radio Name. This is something that was requested by a user in the irc channel.

Lastly: the addition of a menu item to disable the boot demo. For one I prefer the radio to boot as fast as possible, and for the second removing the demo brings back the boot chime. It would be good to add the version and credits somewhere else, but I couldn't find how to get the right menu pane to open, so it'll be for another time.