### PR TITLE
Cleanup of char conversions with radio name

### DIFF
--- a/applet/src/addl_config.c
+++ b/applet/src/addl_config.c
@@ -33,7 +33,7 @@ void cfg_fix_dmrid()
 void cfg_fix_radioname()
 {
     if( global_addl_config.rname[0] != 0x00 ) {
-        md380_spiflash_write((wchar_t *)&global_addl_config.rname[0], FLASH_OFFSET_RNAME, 32);
+        md380_spiflash_write(&global_addl_config.rname[0], FLASH_OFFSET_RNAME, 32);
         for (uint8_t ii = 0; ii < 32; ii++) {
             md380_radio_config.radioname[ii] = global_addl_config.rname[ii];
         }

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -7,8 +7,9 @@
 
 #include <stdint.h>
 
-#define FLASH_OFFSET_DMRID 0x2084
-#define FLASH_OFFSET_RNAME 0x20B0
+#define FLASH_OFFSET_DMRID           0x2084
+#define FLASH_OFFSET_RNAME           0x20B0
+#define FLASH_OFFSET_BOOT_BOTTONLINE 0x2054
 
 // Obvious note to newbies... these live in SPI...
 // This means they should never be reordered 

--- a/applet/src/main.c
+++ b/applet/src/main.c
@@ -21,6 +21,7 @@
 #include "gfx.h"
 #include "display.h"
 #include "usersdb.h"
+#include "util.h"
 
 GPIO_InitTypeDef  GPIO_InitStructure;
 
@@ -141,16 +142,8 @@ void demo(void) {
 
 void boot_splash_set_bottomline_dmrid(void) {
   // Set the bottom line to the config's dmr id
-  char dmridstr[10] = {0x00};
-  sprintf(dmridstr, "%u\0", (uint32_t)global_addl_config.dmrid);
-  // We need to pad for wchar, someone will probably rip out their eyeballs reading this
-  //mbstowcs(&botlinetext, dmridstr, 10);
-  for (uint8_t ii = 0; ii < 20; ii++) {
-    botlinetext[ii] = 0x00;
-    if (ii%2 == 0) {
-        botlinetext[ii] = dmridstr[ii/2];
-    }
-  }
+  for (uint8_t ii = 0 ; ii < 20; ii++) { botlinetext[ii] = 0x00; }
+  uli2w((uint32_t)global_addl_config.dmrid, (wchar_t *)&botlinetext[0]);
 }
 
 void boot_splash_set_topline_radioname(void) {
@@ -162,12 +155,8 @@ void boot_splash_set_topline_radioname(void) {
 void boot_splash_set_bottomline_fullname(void) {
   char fullname[10] = {0x00};
   if ( get_dmr_user_field(3, fullname, global_addl_config.dmrid, 10) ) {
-    for (uint8_t ii = 0 ; ii < 20; ii++) {
-      botlinetext[ii] = 0x00;
-      if (ii%2 == 0) {
-          botlinetext[ii] = fullname[ii/2];
-      }
-    }
+    for (uint8_t ii = 0 ; ii < 20; ii++) { botlinetext[ii] = 0x00; }
+    wide_sprintf((wchar_t *)&botlinetext[0], fullname, 10);
   }
 }
 
@@ -183,7 +172,7 @@ void boot_splash(void) {
       boot_splash_set_bottomline_fullname();
       break;
     default:
-      md380_spiflash_read(botlinetext, 0x2054, 20);
+      md380_spiflash_read(botlinetext, FLASH_OFFSET_BOOT_BOTTONLINE, 20);
       break;
   }
 }

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -22,6 +22,7 @@
 #include "addl_config.h"
 #include "radio_config.h"
 #include "usersdb.h"
+#include "util.h"
 
 const static wchar_t wt_addl_func[]         = L"MD380Tools";
 const static wchar_t wt_datef[]             = L"Date format";
@@ -916,25 +917,6 @@ void create_menu_entry_edit_dmr_id_screen_store(void)
 #ifdef CONFIG_MENU
     md380_create_menu_entry(md380_menu_id, md380_menu_edit_buf, MKTHUMB(md380_menu_entry_back), MKTHUMB(md380_menu_entry_back), 6, 1, 1);
 #endif
-}
-
-uint32_t uli2w(uint32_t num, wchar_t *bf)
-{
-    int n = 0;
-    unsigned int d = 1;
-    while (num / d >= 10)
-        d *= 10;
-    while (d != 0) {
-        int dgt = num / d;
-        num %= d;
-        d /= 10;
-        if( n || dgt > 0 || d == 0 ) {
-            *bf++ = dgt + '0';
-            ++n;
-        }
-    }
-    *bf = 0;
-    return (n); // number of char
 }
 
 void create_menu_entry_edit_dmr_id_screen(void)

--- a/applet/src/util.c
+++ b/applet/src/util.c
@@ -3,6 +3,7 @@
  * 
  */
 
+#include <stdint.h>
 #include "util.h"
 
 void mkascii( char *dst, int dstlen, wchar_t *src )
@@ -15,5 +16,24 @@ void mkascii( char *dst, int dstlen, wchar_t *src )
         }
     }
     *dst = 0 ;
+}
+
+uint32_t uli2w(uint32_t num, wchar_t *bf)
+{
+    int n = 0;
+    unsigned int d = 1;
+    while (num / d >= 10)
+        d *= 10;
+    while (d != 0) {
+        int dgt = num / d;
+        num %= d;
+        d /= 10;
+        if( n || dgt > 0 || d == 0 ) {
+            *bf++ = dgt + '0';
+            ++n;
+        }
+    }
+    *bf = 0;
+    return (n); // number of char
 }
 

--- a/applet/src/util.h
+++ b/applet/src/util.h
@@ -10,10 +10,11 @@
 extern "C" {
 #endif
 
-#include <stddef.h>    
-    
+#include <stddef.h>
+
 void mkascii( char *dst, int dstlen, wchar_t *src );
 
+uint32_t uli2w(uint32_t num, wchar_t *bf);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
As my comment pointed out (https://github.com/travisgoodspeed/md380tools/commit/d9c3e74c617cfda693480edbb45c086b29e93bd5#diff-640dfd36b4bb6c32be4aee1be95b82b2R178) I was sure this was wrong (looked for wchar.h at the time), thanks to @iddq :+1: for pointing me in the right direction.

I've moved and exported uli2w to util.c for convenience.