### PR TITLE
Remove all trailing whitespace at end of lines in python stuff

### DIFF
--- a/DFU.py
+++ b/DFU.py
@@ -27,7 +27,7 @@ class Enumeration(object):
     def create_from_map(cls):
         for id, name in cls.map.iteritems():
             cls(id, name)
-        
+
 class Request(Enumeration):
     map = {
         0: 'DETACH',
@@ -112,8 +112,8 @@ class DFU(object):
         self.md380_custom(0xA2,0x08); #Access the clock memory.
         time=self.upload(0,7);  #Read the time bytes as BCD.
         #hexdump("Time is: "+time);
-        
-        
+
+
         from datetime import datetime;
         dt=datetime(self.bcd(time[0])*100+self.bcd(time[1]),
                              self.bcd(time[2]),
@@ -173,7 +173,7 @@ class DFU(object):
             print "Failed to send custom %02x %02x." % (a,b);
             return False;
         return True;
-    
+
     def md380_reboot(self):
         """Sends the MD380's secret reboot command.""";
         a=0x91;
@@ -193,7 +193,7 @@ class DFU(object):
                                           index,            #index
                                           length)       #length
         return data
-    
+
     def get_command(self):
         data = self._device.ctrl_transfer(0xA1, #request type
                                           Request.UPLOAD, #request
@@ -202,7 +202,7 @@ class DFU(object):
                                           32) #length
         self.get_status();
         return data
-    
+
     def get_status(self):
         status_packed = self._device.ctrl_transfer(0xA1, Request.GETSTATUS, 0, 0, 6)
         status = struct.unpack('<BBBBBB', status_packed)
@@ -243,7 +243,7 @@ class DFU(object):
             State.dfuMANIFEST_WAIT_RESET: self._wait,
             State.dfuIDLE: self._wait
         }
-        
+
         while True:
             state = self.get_state()
             if state == State.dfuIDLE:
@@ -253,7 +253,7 @@ class DFU(object):
 
     def _wait(self):
         time.sleep(0.1)
-    
+
     def widestr(self,str):
         tr="";
         for c in str:

--- a/applet/ppm2h.py
+++ b/applet/ppm2h.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
-import sys   
+import sys
 import struct
-import os  
+import os
 import math
 import binascii
 import argparse
 import re
 
 class MD380Graphics():
-    @staticmethod    
+    @staticmethod
     def gfxprintpal(gfx,name):
-        byte_cnt=0        
+        byte_cnt=0
         palstring = ''
         for color in gfx['palette']:
              r, g, b, a = color
@@ -26,15 +26,15 @@ class MD380Graphics():
              palstring +=  ', ' + "0x" + str(hex(b)[2:].zfill(2))
              palstring +=  ', ' + "0x" + str(hex(a)[2:].zfill(2))
              byte_cnt+=1
-             
-        print ("char %s_paltab[] = {" % name )    
+
+        print ("char %s_paltab[] = {" % name )
         print (palstring)
-        print ("  };")                                                                                       
- 
+        print ("  };")
+
     @staticmethod
     def gfxprintpix(gfx,name):
         bitsperpixel = int(math.ceil(math.log(len(gfx['palette']))/math.log(2)))
-        byte_cnt=0         
+        byte_cnt=0
         pixstring = ''
         for line in gfx['pixels']:
             padding =  gfx['width'] - len(line)
@@ -44,16 +44,16 @@ class MD380Graphics():
 
             for i in xrange(0, len(linebits), 8):
                 if byte_cnt == 0:
-                    pixstring =  "  0x" + str(hex(int(linebits[i:i+8], 2))[2:].zfill(2)) 
+                    pixstring =  "  0x" + str(hex(int(linebits[i:i+8], 2))[2:].zfill(2))
                 else:
                     pixstring += ','
                     if byte_cnt % 20 == 0:
                         pixstring += '\n  '
                     pixstring += "0x" + str(hex(int(linebits[i:i+8], 2))[2:].zfill(2))
                 byte_cnt+=1
-        print ("char %s_pix[] = {" % name )    
+        print ("char %s_pix[] = {" % name )
         print (pixstring)
-        print ("  };")     
+        print ("  };")
 
 
     @staticmethod
@@ -67,10 +67,10 @@ class MD380Graphics():
               int(math.ceil(math.log(len(gfx['palette']))/math.log(2))),
               name,
               name ))
-                    
-                                
+
+
     @staticmethod
-    def ppmparse(ppm):     # stolen from md380-gfx 
+    def ppmparse(ppm):     # stolen from md380-gfx
         """Convert PPM(P6) image to sprite object"""
         ppml = ppm.split('\n')
         assert ppml[0] == 'P6'
@@ -91,7 +91,7 @@ class MD380Graphics():
         width = int(width)
         height = int(height)
         maxc = int(ppml[i+1])
-        assert maxc == 255   
+        assert maxc == 255
         data = '\n'.join(ppml[i+2:])
         paletteidx = {}
         pixels = []
@@ -111,7 +111,7 @@ class MD380Graphics():
                     palette.append([r, g, b, a])
                     paletteidx[key] = color
                 line.append(color)
-            pixels.append(line)   
+            pixels.append(line)
         img = {'address': addr, 'width': width, 'height': height,
                'palette': palette, 'pixels': pixels,
                'oldchecksum': oldchecksum, 'oldpalette': oldpalette}
@@ -136,8 +136,8 @@ def main():
         gfx = md.ppmparse(gfx)
     name=re.sub(r'\.ppm$','',args.gfx)
     md.gfxprintpal(gfx,name)
-    md.gfxprintpix(gfx,name) 
+    md.gfxprintpix(gfx,name)
     md.gfxprintstruct(gfx,name)
-    
+
 if __name__ == "__main__":
     main()

--- a/chirp/md380.py
+++ b/chirp/md380.py
@@ -113,7 +113,7 @@ struct { //0x1F025 into rdt
                          // |1 is vox enabled
                         // low nibble: unknown, usually 0x4
                        // 0 0  0 0   0 0  0 0
-                       // CcCf HpVx            
+                       // CcCf HpVx
 
   char wasc3;          //Unknown, normally C3
   ul16 contact;        //Digital contact name.  (TX group.)  TODO
@@ -174,7 +174,7 @@ struct {
 //      0x15 is squelch toggle
 //      0x16 is privacy toggle
 //      0x17 is vox toggle
-//      0x18 is zone select 
+//      0x18 is zone select
 //      0x1e is manual dial for private
 //      0x1f is lone work toggle
 
@@ -196,16 +196,16 @@ struct {
                     //  |2 is remote monitor
                     //  |1 is radio check
                     // lower:
-                    //  |8 is 
-                    //  |4 is 
-                    //  |2 is 
+                    //  |8 is
+                    //  |4 is
+                    //  |2 is
                     //  |1 is
     char utilities1; //when all options available, 0xff
     char utilities2; //when all options available, 0xbf
         // 0x3f if vox disabled, 0xbf if vox enabled
     char utilities3; //when all options on, 0xfb
         // 0xfb if front panel programming allowed, 0xff is fpp disabled
-    
+
 } menuoptions;
 
 #seekto 0x149e0;
@@ -232,7 +232,7 @@ struct {
     u8 flags1; //FE
     u8 flags2; //6B for no beeps, 6F will all beeps.
     u8 flags3; //EE
-    u8 flags4; //FF 
+    u8 flags4; //FF
     ul32 dmrid; //0x2084
     u8 flags5[13];  //Unknown settings, seem mostly used.
     u8 screenlit; //00 for infinite delay, 01 for 5s, 02 for 10s, 03 for 15s.
@@ -305,13 +305,13 @@ def asctoutf(ascstring,size=None):
     for c in ascstring:
         toret=toret+c+"\x00";
     if size==None: return toret;
-    
+
     #Correct the size here.
     while len(toret)<size:
         toret=toret+"\x00";
 
     return toret[:size];
-    
+
 class MD380Bank(chirp_common.NamedBank):
     """A VX3 Bank"""
     def get_name(self):
@@ -372,7 +372,7 @@ class MD380BankModel(chirp_common.MTOBankModel):
 
     def get_mapping_memories(self, bank):
         memories = []
-        
+
         _members = self._radio._memobj.bank[bank.index].members
         #_bank_used = self._radio._memobj.bank_used[bank.index]
 
@@ -383,7 +383,7 @@ class MD380BankModel(chirp_common.MTOBankModel):
             #Zero items are not memories.
             if number == 0x0000:
                 continue
-            
+
             mem=self._radio.get_memory(number);
             print "Appending memory %i" % number;
             memories.append(mem)
@@ -406,7 +406,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
     MODEL = "MD-380"
     FILE_EXTENSION = "img"
     BAUD_RATE = 9600    # This is a lie.
-    
+
     _memsize=262144;
     @classmethod
     def match_model(cls, filedata, filename):
@@ -414,8 +414,8 @@ class MD380Radio(chirp_common.CloneModeRadio):
                len(filedata) == cls._memsize
             or len(filedata) == cls._memsize+565
             );
-    
-    
+
+
     # Return information about this radio's features, including
     # how many memories it has, what bands it supports, etc
     def get_features(self):
@@ -426,7 +426,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
         rf.can_odd_split = True
         rf.valid_tmodes = TMODES
         rf.memory_bounds = (1, 999)  # Maybe 1000?
-        
+
         rf.valid_bands = [(400000000, 480000000), # 70cm model is most common.
                           (136000000, 174000000)  # 2m model sold separately.
                           ]
@@ -443,7 +443,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
         rf.valid_duplexes = list(DUPLEX)
         rf.valid_name_length = 16
         return rf
-    
+
     # Processes the mmap from a file.
     def process_mmap(self):
         if(len(self._mmap)==self._memsize):
@@ -453,11 +453,11 @@ class MD380Radio(chirp_common.CloneModeRadio):
 
         #self._memobj = bitwise.parse(
         #    MEM_FORMAT, self._mmap)
-    
+
     # Do a download of the radio from the serial port
     def sync_in(self):
         pass;
-    
+
 #         try:
 #             self._mmap = do_download(self)
 #         except errors.RadioError:
@@ -465,7 +465,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
 #         except Exception, e:
 #             raise errors.RadioError("Failed to communicate with radio: %s" % e)
 #         #hexdump(self._mmap);
-        
+
 #         if(len(self._mmap)==self._memsize):
 #             self._memobj = bitwise.parse(MEM_FORMAT, self._mmap)
 #         else:
@@ -485,18 +485,18 @@ class MD380Radio(chirp_common.CloneModeRadio):
     def get_memory(self, number):
         # Get a low-level memory object mapped to the image
         _mem = self._memobj.memory[number-1]
-        
+
         # Create a high-level memory object to return to the UI
         mem = chirp_common.Memory()
 
         mem.number = number;
         mem.name = utftoasc(str(_mem.name)).rstrip()  # Set the alpha tag
         mem.freq = int(_mem.rxfreq)*10;
-        
+
         ctone=int(_mem.ctone)/10.0;
         rtone=int(_mem.rtone)/10.0;
 
-        
+
         # Anything with an unset frequency is unused.
         # Maybe we should be looking at the mode instead?
         if mem.freq >500e6:
@@ -507,9 +507,9 @@ class MD380Radio(chirp_common.CloneModeRadio):
             mem.duplex=""
             mem.offset=mem.freq;
             _mem.mode=0x61; #Narrow FM.
-        
 
-        
+
+
         #print "Tones for %s are %s and %s" %(
         #    mem.name, rtone, ctone);
         #mem.rtone=91.5
@@ -543,7 +543,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
             mem.offset=6e5;
         else:
             mem.duplex="split";
-        
+
         mem.mode="DIG";
         rmode=_mem.mode&0x0F;
         if rmode==0x02:
@@ -556,7 +556,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
             print "WARNING: Mode bytes 0x%02 isn't understood for %s." % (
                 _mem.mode, mem.name);
 
-        
+
         return mem
 
     # Store details about a high-level memory to the memory map
@@ -567,7 +567,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
 
         # Convert to low-level frequency representation
         _mem.rxfreq = mem.freq/10;
-        
+
         # Janky offset support.
         # TODO Emulate modes other than split.
         if mem.duplex=="split":
@@ -579,13 +579,13 @@ class MD380Radio(chirp_common.CloneModeRadio):
         else:
             _mem.txfreq = _mem.rxfreq;
         _mem.name = asctoutf(mem.name,32);
-        
+
         #print "Tones in mode %s of %s and %s for %s" % (
         #    mem.tmode, mem.ctone, mem.rtone, mem.name);
         # These need to be 16665 when unused.
         _mem.ctone=mem.ctone*10;
         _mem.rtone=mem.rtone*10;
-        
+
         if mem.tmode=="Tone":
             blankbcd(_mem.ctone); #No receiving tone.
         elif mem.tmode=="TSQL":
@@ -593,7 +593,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
         else:
             blankbcd(_mem.ctone);
             blankbcd(_mem.rtone);
-        
+
         if mem.mode=="FM":
             _mem.mode=0x69;
         elif mem.mode=="NFM":
@@ -602,7 +602,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
             _mem.mode=0x62;
         else:
             _mem.mode=0x69;
-        
+
         if _mem.slot==0xff:
             _mem.slot=0x14;  #TODO Make this 0x18 for S2.
 
@@ -610,12 +610,12 @@ class MD380Radio(chirp_common.CloneModeRadio):
     def get_settings(self):
         _general = self._memobj.general
         _info = self._memobj.info
-        
+
         basic = RadioSettingGroup("basic", "Basic")
         info = RadioSettingGroup("info", "Model Info")
         general = RadioSettingGroup("general", "General Settings");
-        
-        
+
+
         #top = RadioSettings(identity, basic)
         top = RadioSettings(general)
         general.append(RadioSetting(
@@ -641,7 +641,7 @@ class MD380Radio(chirp_common.CloneModeRadio):
                 setting = element.get_name()
                 #oldval = getattr(_settings, setting)
                 newval = element.value
-                
+
                 #LOG.debug("Setting %s(%s) <= %s" % (setting, oldval, newval))
                 if setting=="line1":
                     _general.line1=asctoutf(str(newval),20);

--- a/md380_dfu.py
+++ b/md380_dfu.py
@@ -80,7 +80,7 @@ def download(dfu, data, flash_address):
 def download_codeplug(dfu, data):
     """Downloads a codeplug to the MD380."""
     block_size = 1024
-    
+
     dfu.md380_custom(0x91,0x01); #Programming Mode
     dfu.md380_custom(0x91,0x01); #Programming Mode
     #dfu.md380_custom(0xa2,0x01); #Returns "DR780...", seems to crash client.
@@ -92,7 +92,7 @@ def download_codeplug(dfu, data):
     dfu.md380_custom(0xa2,0x03);
     dfu.md380_custom(0xa2,0x04);
     dfu.md380_custom(0xa2,0x07);
-    
+
 
     dfu.erase_block(0x00000000);
     dfu.erase_block(0x00010000);
@@ -100,14 +100,14 @@ def download_codeplug(dfu, data):
     dfu.erase_block(0x00030000);
 
     dfu.set_address(0x00000000); # Zero address, used by configuration tool.
-    
+
     #sys.exit();
-    
+
     status, timeout, state, discarded = dfu.get_status()
     #print status, timeout, state, discarded
-    
+
     block_number = 2
-    
+
     try:
         while len(data) > 0:
             packet, data = data[:block_size], data[block_size:]
@@ -137,24 +137,24 @@ def hexdump(string):
             buf=buf+"   "
         if i&0x1f==0:
             buf=buf+"\n"
-        
+
     print buf;
 
 
 def upload_bootloader(dfu,filename):
     """Dumps the bootloader, but only on Mac."""
     #dfu.set_address(0x00000000); # Address is ignored, so it doesn't really matter.
-    
+
     # Bootloader stretches from 0x08000000 to 0x0800C000, but our
     # address and block number are ignored, so we set the block size
     # ot 0xC000 to yank the entire thing in one go.  The application
     # comes later, I think.
     block_size=0xC000; #0xC000;
-    
+
     f=None;
     if filename!=None:
         f=open(filename,'wb');
-    
+
     print "Dumping bootloader.  This only works in radio mode, not programming mode."
     try:
         data = dfu.upload(2, block_size)
@@ -168,7 +168,7 @@ def upload_bootloader(dfu,filename):
             f.write(data)
         else:
             hexdump(data);
-        
+
     finally:
         print "Done."
 
@@ -183,9 +183,9 @@ def upload_codeplug(dfu,filename):
     dfu.md380_custom(0xa2,0x03);
     dfu.md380_custom(0xa2,0x04);
     dfu.md380_custom(0xa2,0x07);
-    
+
     dfu.set_address(0x00000000); # Zero address, used by configuration tool.
-    
+
     f = open(filename, 'wb')
     block_size=1024
     try:
@@ -296,10 +296,10 @@ radio will be radio to accept this firmware update.""");
 def upload(dfu, flash_address, length, path):
     #block_size = 1 << 8
     block_size = 1 << 14
-    
+
     print "Address: 0x%08x"%flash_address
     print "Block Size:    0x%04x"%block_size
-    
+
     if flash_address & (block_size - 1) != 0:
         raise Exception('Upload must start at block boundary')
 
@@ -307,18 +307,18 @@ def upload(dfu, flash_address, length, path):
     assert block_number * block_size == flash_address
     #block_number=0x8000;
     print "Block Number:    0x%04x"%block_number
-    
-    
+
+
     cmds=dfu.get_command();
     print "%i supported commands." % len(cmds)
     for cmd in cmds:
         print "Command %02x is supported by UPLOAD."%cmd;
-    
+
     dfu.set_address(0x08001000); #RAM
     block_number=2;
-    
+
     f = open(path, 'wb')
-   
+
     try:
         while length > 0:
             data = dfu.upload(block_number, block_size)
@@ -348,7 +348,7 @@ def detach(dfu):
 def init_dfu(alt=0):
     dev = usb.core.find(idVendor=md380_vendor,
                         idProduct=md380_product)
-    
+
     if dev is None:
         raise RuntimeError('Device not found')
 
@@ -407,7 +407,7 @@ def main():
                 upload_codeplug(dfu, sys.argv[2])
                 print('Read complete')
             elif sys.argv[1] == 'readboot':
-                print "This only wokrs from OS X.  Use the one in md380-tool with patched firmware for other bootloaders.";
+                print "This only works from OS X.  Use the one in md380-tool with patched firmware for other bootloaders.";
                 import usb.core
                 dfu = init_dfu()
                 upload_bootloader(dfu, sys.argv[2])
@@ -435,7 +435,7 @@ def main():
                 else:
                     dfu = init_dfu()
                     firmware = data
-                
+
 
                 download_codeplug(dfu, firmware)
                 print('Write complete')
@@ -468,7 +468,7 @@ def main():
                 import usb.core
                 dfu = init_dfu()
 		print dfu.get_time();
-                
+
             elif sys.argv[1] == 'reboot':
                 import usb.core
                 dfu = init_dfu()

--- a/md380_gfx.py
+++ b/md380_gfx.py
@@ -107,13 +107,13 @@ class MD380Graphics(Memory):
         """Parse sprite structure and return image"""
         s = struct.Struct('<hhhhLL')
         width, height, bytesperline, bitsperpixel, pixptr, palptr = s.unpack_from(self.mem, addr-self.addr)
-    
+
         s = struct.Struct('<llL')
         ncol, someb, colptr = s.unpack_from(self.mem, palptr-self.addr)
 
         #bitplanes = len(bin(ncol-1))-2
         img = {'address': addr, 'width': width, 'height': height, 'palette': None, 'pixels': []}
-        
+
         img['palette'] = []
         for i in xrange(colptr, colptr+ncol*4, 4):
             r, g, b, a = self.read(i, 4)
@@ -132,18 +132,18 @@ class MD380Graphics(Memory):
         s = struct.Struct('<bbbbL')
         width, height, bytesperline, somea, pixptr = s.unpack_from(self.mem, addr-self.addr)
         # somea seems to be padding; always 0 in v2.32
-    
+
         #sys.stdout.write('glyphparse: address 0x%x wid=%d height=%d  bpl=%d  somea=%d  pixptr=0x%x\n' % (addr, width, height, bytesperline, somea, pixptr) )
         if height <= 8:
             height = height * 2  # CN characters are right height, latin are reported 1/2 height
-    
+
         img = {'address': addr, 'width': width, 'height': height, 'palette': None, 'pixels': []}
-    
+
         for y in xrange(height):
             linebits = self.readbits(pixptr+y*bytesperline, width)
             line = [int(color) for color in linebits]
             img['pixels'].append(line)
-        
+
         img['checksum'] = self.gfxchecksum(img)
         return img
 
@@ -276,13 +276,13 @@ class MD380Graphics(Memory):
                 r, g, b, a = gfx['palette'][color]
                 sys.stdout.write(MD380Graphics.bashcolor(r, g, b)+' ')
             sys.stdout.write(MD380Graphics.bashcolor()+'\n')
-    
+
     @staticmethod
     def glyphshow(gfx):
         for line in gfx['pixels']:
             sys.stdout.write(''.join(line)+'\n')
-    
-    @staticmethod    
+
+    @staticmethod
     def gfxprint(gfx):
         print("%s %d×%d" % (hex(gfx['address']), gfx['width'], gfx['height']))
         print("%s" % repr(gfx['palette']))
@@ -294,7 +294,7 @@ class MD380Graphics(Memory):
                     px = hex(color)[-1]  # ensure single char for color
                 sys.stdout.write(px)
             sys.stdout.write('\n')
-    
+
     @staticmethod
     def ppm(gfx):
         """Convert sprite object to PPM(P6) image"""
@@ -370,11 +370,11 @@ class MD380Graphics(Memory):
         out += '%d %d\n' % (gfx['width'], gfx['height'])
         for line in gfx['pixels']:
             bitline = ''.join([str(pixel) for pixel in line])
-            
+
             #ASCII output (P1)
             sys.stdout.write('bit line  %s\n' % bitline)
             out += bitline + '\n'
-            
+
             #Hex ouput (P4) - OSX doesn't render non-byte widths correctly (like all latin fonts)
             #bitline += '0' * ((8 - len(bitline)) % 8)  # pad to full byte
             #hexline = hex(int('1'+bitline, 2))[3:]
@@ -403,7 +403,7 @@ class MD380Graphics(Memory):
         width, height = pbml[i].split()
         width = int(width)
         height = int(height)
-        
+
         #bytewidth = int(math.ceil(width/8.0))
         #data = b''.join(pbml[i+1:])
         #pixels = []

--- a/md380_tool.py
+++ b/md380_tool.py
@@ -56,7 +56,7 @@ class UsersDB():
                 user[1],
                 user[2],
                 user[0]));
-    
+
 
 #Quick to load, so might as well do it early.
 users=UsersDB();
@@ -65,7 +65,7 @@ users=UsersDB();
 class Tool(DFU):
     """Client class for extra features patched into the MD380's firmware.
     None of this will work with the official firmware, of course."""
-    
+
     def drawtext(self,str,a,b):
         """Sends a new MD380 command to draw text on the screen.."""
         cmd=0x80; #Drawtext
@@ -152,7 +152,7 @@ class Tool(DFU):
         status=self.get_status(); #this gets the status
 #        print status
         return self.upload(1,size,0);
-    
+
     def getinbox(self,address):
         """return non-deleted messages from inbox"""
         buf = self.spiflashpeek(address, 50 * 4 )
@@ -166,7 +166,7 @@ class Tool(DFU):
             elif header[1] == 0x2:
                 message["read"] = False
             else:
-                message["read"] = "N/A"   
+                message["read"] = "N/A"
             message["order"] = (header[2])
             message["index"] = (header[3])
             if not message["deleted"]:
@@ -230,7 +230,7 @@ class Tool(DFU):
         #time.sleep(0.1);
         status=self.get_status(); #this gets the status
         buf=self.upload(1,1024,0); #Peek the 1024 byte dmesg buffer.
-        
+
         #Okay, so at this point we have the buffer, but it's a ring
         #buffer that might have already looped, so we need to reorder
         #if that is the case or crop it if it isn't.
@@ -254,7 +254,7 @@ class Tool(DFU):
 def calllog(dfu):
     """Prints a call log to stdout, fetched from the MD380's memory."""
     dfu.drawtext("Hooking calls!",160,50);
-    
+
     #Set the target address to the list of DMR addresses.
     dfu.set_address(0x2001d098);
     old1=0;
@@ -358,7 +358,7 @@ def flashgetid(dfu):
     elif (buf[0] == 0x10 and buf[1] == 0xdc):
         if (buf[2] == 0x01):
             sys.stdout.write("W25Q128FV 16MByte maybe\n");
-            size=16*1024*1024;          
+            size=16*1024*1024;
     else:
             sys.stdout.write("Unkown SPI Flash - please report\n");
     return size;
@@ -390,7 +390,7 @@ def spiflashwrite(dfu,filename,adr):
             data = f.read()
             size=len(data)
             dfu.md380_custom(0x91,0x01);  # disable any radio and UI events
-                                          # while on spi flash 
+                                          # while on spi flash
             print "erase %d bytes @ 0x%x" % (size, adr);
             for n in range(adr,adr+size+1,0x1000):
 #                print "erase %x " % n
@@ -406,7 +406,7 @@ def spiflashwrite(dfu,filename,adr):
             if ( lastpartsize  > 0 ):
 #                print "%d  %x %d " % (fullparts,  adr+fullparts*1024, lastpartsize)
                 dfu.spiflashpoke(adr+fullparts*1024,lastpartsize,data[(fullparts)*1024:(fullparts)*1024+lastpartsize]);
-            sys.stdout.write("reboot radio now\n"); 
+            sys.stdout.write("reboot radio now\n");
             dfu.md380_reboot();
             f.close();
      else:
@@ -518,13 +518,13 @@ def readword(dfu, address):
 def init_dfu(alt=0):
     dev = usb.core.find(idVendor=md380_vendor,
                         idProduct=md380_product)
-    
+
     if dev is None:
         raise RuntimeError('Device not found')
 
     dfu = Tool(dev, alt)
     dev.default_timeout = 3000
-    
+
     try:
         dfu.enter_dfu_mode()
         pass;
@@ -533,7 +533,7 @@ def init_dfu(alt=0):
             raise RuntimeError('Failed to enter DFU mode. Is bootloader running?')
         else:
             raise e
-    
+
     return dfu
 
 def usage():
@@ -604,7 +604,7 @@ def main():
                 calldate(dfu);
             elif sys.argv[1] == 'adc1':
                 dfu=init_dfu();
-                calladc1(dfu);         	    	
+                calladc1(dfu);
             elif sys.argv[1] == 'channel':
                 dfu=init_dfu();
                 getchannel(dfu);
@@ -626,7 +626,7 @@ def main():
             elif sys.argv[1] == 'spiflashid':
                 dfu=init_dfu();
                 flashgetid(dfu);
-            
+
         elif len(sys.argv) == 3:
             if sys.argv[1] == 'flashdump':
                 print "Dumping flash from 0x08000000 to '%s'." % sys.argv[2];

--- a/patches/2.032/Patcher.py
+++ b/patches/2.032/Patcher.py
@@ -1,14 +1,14 @@
 
 class Patcher():
     """MD380 Firmware Patching Tool"""
-    
+
     # #Includes Bootloader
     # offset=0x08000000;
-    
+
     #Just the application.
     offset=0x0800C000;
-    
-    
+
+
     def getbyte(self,adr):
         """Reads a byte from the firmware address."""
         b=self.bytes[adr-self.offset];
@@ -21,9 +21,9 @@ class Patcher():
             (self.bytes[adr-self.offset+2]<<16)+
             (self.bytes[adr-self.offset+3]<<24)
             );
-            
+
         return w;
-    
+
     def assertbyte(self, adr, val):
         """Asserts that a byte has a given value."""
         assert self.getbyte(adr)==val;
@@ -59,7 +59,7 @@ class Patcher():
         #Null terminate.
         self.bytes[adr-self.offset]=0;
         self.bytes[adr-self.offset+1]=0;
-    
+
     def sethword(self, adr, new, old=None):
         """Patches a byte pair from the old value to the new value."""
         if old!=None:
@@ -77,7 +77,7 @@ class Patcher():
             self.assertbyte(adr+1,(old>>8)&0xFF);
             self.assertbyte(adr+2,(old>>16)&0xFF);
             self.assertbyte(adr+3,(old>>24)&0xFF);
-        
+
         print "Patching word at %08x to %08x" % (adr,new)
         self.bytes[adr-self.offset]=new&0xFF;
         self.bytes[adr-self.offset+1]=(new>>8)&0xFF;
@@ -137,5 +137,3 @@ class Patcher():
             b=(b<<1);
 
         return;
-    
-    

--- a/patches/2.032/patch.py
+++ b/patches/2.032/patch.py
@@ -12,7 +12,7 @@ monitormodeprivate=False;
 if __name__ == '__main__':
     print "Creating patches from unwrapped.img.";
     patcher=Patcher("unwrapped.img");
-    
+
 
 #     #These aren't quite enough to skip the Color Code check.  Not sure why.
     patcher.nopout(0x0803ea62,0xf040);  #Main CC check.
@@ -25,7 +25,7 @@ if __name__ == '__main__':
                      0xd02d);
     patcher.nopout(0x0803eafe,0xf100); #Disable CRC check, in case CC is included.
     patcher.nopout(0x0803eb00,0x80af);
-    
+
 
     #Disable the ALPU Licence Check (vocoder version)
     patcher.nopout(0x8032a54);
@@ -50,12 +50,12 @@ if __name__ == '__main__':
     patcher.nopout(0x8047f6c+2);
     patcher.nopout(0x8048904);
     patcher.nopout(0x8048904+2);
-        
+
     # Patches after here allow for an included applet.
-    
+
     #This cuts out the Chinese font, freeing ~200k for code patches.
     patcher.ffrange(0x809c714,0x80d0f80);
-    
+
     #This mirrors the RESET vector to 0x080C020, for use in booting.
     patcher.setword(0x0800C020,
                     patcher.getword(0x0800C004),
@@ -66,9 +66,9 @@ if __name__ == '__main__':
     patcher.setword(0x0800C004,
                     0x0809cf00+1
     );
-    
 
-    
+
+
     #This stub calls the target RESET vector,
     #if it's not FFFFFFFF.
     patcher.sethword(0x0809cf00, 0x4840);
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     patcher.sethword(0x0809cf0a, 0x483c);
     patcher.sethword(0x0809cf0c, 0x4700);
 
-    #### Disable power on password (to flash an virgin codeplug 
+    #### Disable power on password (to flash an virgin codeplug
     #### with no password, if you lost this)
     ### patcher.sethword(0x0801a4fe, 0xbdf7);
 
@@ -89,31 +89,30 @@ if __name__ == '__main__':
     #             0x0809cf04      0139           subs r1, 1
     #             0x0809cf06      0845           cmp r0, r1
     #         ,=< 0x0809cf08      00d1           bne 0x809cf0c
-    #         |   0x0809cf0a      3c48           ldr r0, [pc, 0xf0]          ; [0x809cffc:4]=0x80fa969 
+    #         |   0x0809cf0a      3c48           ldr r0, [pc, 0xf0]          ; [0x809cffc:4]=0x80fa969
     #         `-> 0x0809cf0c      0047           bx r0
-    # [0x0809cf00]> 
+    # [0x0809cf00]>
 
-    
+
     #Stores the RESET handler for our stub.
     patcher.setword(0x809cffc,
                     patcher.getword(0x0800C020),
                     0xFFFFFFFF);
-    
-    
+
+
     #Marks the version as "md380tools"
     patcher.setwstring(0x080d14d8,
                       "MD380Tools Ver.");
-    
+
     #Change the manufacturer string.
     patcher.setstring(0x080f9e4c,
                       "Travis Goodspeed KK4VCZ");
     #Change the device name.
     patcher.setstring(0x080d1820,
                       "Patched MD380");
-    
+
     #Fixes a typo in 2.032.  Unneeded in 2.034.
     patcher.setwstring(0x080d17e8,
                       "Repeater Slot"); #was 'Repeatar Slot'
-    
+
     patcher.export("patched.img");
-    

--- a/patches/3.020/Patcher.py
+++ b/patches/3.020/Patcher.py
@@ -1,14 +1,14 @@
 
 class Patcher():
     """MD380 Firmware Patching Tool"""
-    
+
     # #Includes Bootloader
     # offset=0x08000000;
-    
+
     #Just the application.
     offset=0x0800C000;
-    
-    
+
+
     def getbyte(self,adr):
         """Reads a byte from the firmware address."""
         b=self.bytes[adr-self.offset];
@@ -21,9 +21,9 @@ class Patcher():
             (self.bytes[adr-self.offset+2]<<16)+
             (self.bytes[adr-self.offset+3]<<24)
             );
-            
+
         return w;
-    
+
     def assertbyte(self, adr, val):
         """Asserts that a byte has a given value."""
         assert self.getbyte(adr)==val;
@@ -59,7 +59,7 @@ class Patcher():
         #Null terminate.
         self.bytes[adr-self.offset]=0;
         self.bytes[adr-self.offset+1]=0;
-    
+
     def sethword(self, adr, new, old=None):
         """Patches a byte pair from the old value to the new value."""
         if old!=None:
@@ -77,7 +77,7 @@ class Patcher():
             self.assertbyte(adr+1,(old>>8)&0xFF);
             self.assertbyte(adr+2,(old>>16)&0xFF);
             self.assertbyte(adr+3,(old>>24)&0xFF);
-        
+
         print "Patching word at %08x to %08x" % (adr,new)
         self.bytes[adr-self.offset]=new&0xFF;
         self.bytes[adr-self.offset+1]=(new>>8)&0xFF;
@@ -137,5 +137,3 @@ class Patcher():
             b=(b<<1);
 
         return;
-    
-    

--- a/patches/3.020/patch.py
+++ b/patches/3.020/patch.py
@@ -13,5 +13,5 @@ monitormodeprivate=False
 if __name__ == '__main__':
     print "Creating patches from unwrapped.img."
     patcher=Patcher("unwrapped.img")
-    
+
     patcher.export("patched.img")

--- a/patches/d13.020/Patcher.py
+++ b/patches/d13.020/Patcher.py
@@ -1,14 +1,14 @@
 
 class Patcher():
     """MD380 Firmware Patching Tool"""
-    
+
     # #Includes Bootloader
     # offset=0x08000000;
-    
+
     #Just the application.
     offset=0x0800C000;
-    
-    
+
+
     def getbyte(self,adr):
         """Reads a byte from the firmware address."""
         b=self.bytes[adr-self.offset];
@@ -21,9 +21,9 @@ class Patcher():
             (self.bytes[adr-self.offset+2]<<16)+
             (self.bytes[adr-self.offset+3]<<24)
             );
-            
+
         return w;
-    
+
     def assertbyte(self, adr, val):
         """Asserts that a byte has a given value."""
         assert self.getbyte(adr)==val;
@@ -59,7 +59,7 @@ class Patcher():
         #Null terminate.
         self.bytes[adr-self.offset]=0;
         self.bytes[adr-self.offset+1]=0;
-    
+
     def sethword(self, adr, new, old=None):
         """Patches a byte pair from the old value to the new value."""
         if old!=None:
@@ -77,7 +77,7 @@ class Patcher():
             self.assertbyte(adr+1,(old>>8)&0xFF);
             self.assertbyte(adr+2,(old>>16)&0xFF);
             self.assertbyte(adr+3,(old>>24)&0xFF);
-        
+
         print "Patching word at %08x to %08x" % (adr,new)
         self.bytes[adr-self.offset]=new&0xFF;
         self.bytes[adr-self.offset+1]=(new>>8)&0xFF;
@@ -137,5 +137,3 @@ class Patcher():
             b=(b<<1);
 
         return;
-    
-    

--- a/patches/d13.020/patch.py
+++ b/patches/d13.020/patch.py
@@ -12,7 +12,7 @@ monitormodeprivate=False
 if __name__ == '__main__':
     print "Creating patches from unwrapped.img."
     patcher=Patcher("unwrapped.img")
-    
+
 # bypass vocoder copy protection on D013.020
 
     patcher.nopout((0x08033f30+0x18))
@@ -40,20 +40,20 @@ if __name__ == '__main__':
 
 
     # Color Code check
-    
+
     # freeing ~200k for code patches
     patcher.ffrange(0x0809aee8,0x080cf754);
-    
+
     #This mirrors the RESET vector to 0x080C020, for use in booting.
     patcher.setword(0x0800C020,
                     patcher.getword(0x0800C004),
                     0x00000000);
-                                                 
-                                                 
+
+
     #This makes RESET point to our stub below.
     patcher.setword(0x0800C004,
                     0x0809af00+1);
-      
+
     #This stub calls the target RESET vector,
     #if it's not FFFFFFFF.
     patcher.sethword(0x0809af00, 0x4840);
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     patcher.sethword(0x0809af08, 0xd100);
     patcher.sethword(0x0809af0a, 0x483c);
     patcher.sethword(0x0809af0c, 0x4700);
-                                          
+
     #Stores the RESET handler for our stub.
     patcher.setword(0x0809affc,
                     patcher.getword(0x0800C020),

--- a/patches/s13.020/Patcher.py
+++ b/patches/s13.020/Patcher.py
@@ -1,14 +1,14 @@
 
 class Patcher():
     """MD380 Firmware Patching Tool"""
-    
+
     # #Includes Bootloader
     # offset=0x08000000;
-    
+
     #Just the application.
     offset=0x0800C000;
-    
-    
+
+
     def getbyte(self,adr):
         """Reads a byte from the firmware address."""
         b=self.bytes[adr-self.offset];
@@ -21,9 +21,9 @@ class Patcher():
             (self.bytes[adr-self.offset+2]<<16)+
             (self.bytes[adr-self.offset+3]<<24)
             );
-            
+
         return w;
-    
+
     def assertbyte(self, adr, val):
         """Asserts that a byte has a given value."""
         assert self.getbyte(adr)==val;
@@ -59,7 +59,7 @@ class Patcher():
         #Null terminate.
         self.bytes[adr-self.offset]=0;
         self.bytes[adr-self.offset+1]=0;
-    
+
     def sethword(self, adr, new, old=None):
         """Patches a byte pair from the old value to the new value."""
         if old!=None:
@@ -77,7 +77,7 @@ class Patcher():
             self.assertbyte(adr+1,(old>>8)&0xFF);
             self.assertbyte(adr+2,(old>>16)&0xFF);
             self.assertbyte(adr+3,(old>>24)&0xFF);
-        
+
         print "Patching word at %08x to %08x" % (adr,new)
         self.bytes[adr-self.offset]=new&0xFF;
         self.bytes[adr-self.offset+1]=(new>>8)&0xFF;
@@ -137,5 +137,3 @@ class Patcher():
             b=(b<<1);
 
         return;
-    
-    

--- a/patches/s13.020/patch.py
+++ b/patches/s13.020/patch.py
@@ -12,7 +12,7 @@ monitormodeprivate=False
 if __name__ == '__main__':
     print "Creating patches from unwrapped.img."
     patcher=Patcher("unwrapped.img")
-    
+
     # bypass vocoder copy protection on S013.020
     patcher.nopout((0x8034a60))
     patcher.nopout((0x8034a60+0x2))
@@ -73,10 +73,10 @@ if __name__ == '__main__':
     patcher.sethword(0x0809bf08, 0xd100);
     patcher.sethword(0x0809bf0a, 0x483c);
     patcher.sethword(0x0809bf0c, 0x4700);
-                                        
+
     #Stores the RESET handler for our stub.
     patcher.setword(0x0809bffc,
                     patcher.getword(0x0800C020),
                     0xFFFFFFFF);
-                                                                                        
+
     patcher.export("patched.img")

--- a/playground/dmesg2amb.py
+++ b/playground/dmesg2amb.py
@@ -40,8 +40,8 @@ def writeframe(f,frame):
             b=0;
     #There's one bit left over, which takes the LSBit in its own byte.
     f.write(chr(b));
-    
-            
+
+
 outfile=open("output.amb","w");
 writeheader(outfile);
 for r in sys.stdin:
@@ -49,4 +49,4 @@ for r in sys.stdin:
         bits=r.split()[2];
         print bits;
         writeframe(outfile,bits);
-        
+

--- a/playground/dmesg2wav.py
+++ b/playground/dmesg2wav.py
@@ -29,9 +29,9 @@ def writeframe(frame):
     frames=[];
     frames.append(frame);
     outfile.writeframes(chr(frame&0xFF)+""+chr(frame>>8));
-    
-            
-    
+
+
+
 
 #This part is god-awful ugly.  Kill it with fire!
 
@@ -44,5 +44,5 @@ for r in sys.stdin:
             sample=(int(bits[i+1],16)<<8)|int(bits[i],16);
             #if sample&0x8000:
             #    sample= 0-(sample^0xFFFF)
-            
+
             writeframe(sample);

--- a/playground/r2ida.py
+++ b/playground/r2ida.py
@@ -37,7 +37,7 @@ def parse_line(line):
     else: # f and fC are UNHANDLED and appear in script
         print("Unhandled command: {}".format(toks[0]), file=sys.stderr)
         return ''
-        
+
 
 # read input file into lines
 
@@ -46,10 +46,10 @@ def main():
     parser.add_argument('input', nargs=1, help='input file')
     parser.add_argument('output', nargs=1, help='output file')
     args = parser.parse_args()
-    
+
     f = open(args.input[0], 'r')
     g = open(args.output[0], 'w')
-    
+
     g.write(ida_front_boilerplate)
     g.write('\n')
 
@@ -60,7 +60,7 @@ def main():
 
     g.write(ida_end_boilerplate)
     g.write('\n')
-    
+
     g.close()
     f.close()
 

--- a/stm32-dfu
+++ b/stm32-dfu
@@ -74,7 +74,7 @@ class Enumeration(object):
     def create_from_map(cls):
         for id, name in cls.map.iteritems():
             cls(id, name)
-        
+
 class Request(Enumeration):
     map = {
         0: 'DETACH',
@@ -146,16 +146,16 @@ class DFU(object):
                                    data_or_wLength=[0x41]);
         # Erasure doesn't occur until we check the status.
         status=self.get_status();
-        
+
         print "The device is now erasing itself.";
         print "This will result in a USB disconnect.";
         return True;
     def go(self,address=0x08000000):
         """Branch to the address at addrptr+4."""
-        
+
         #Branches to the value stored at the word *AFTER* this address.
         self.setaddresspointer(address);
-        
+
         #Use DNLOAD, not DETACH.
         self._device.ctrl_transfer(bmRequestType=0x21,
                                    bRequest=Request.DNLOAD,
@@ -165,8 +165,8 @@ class DFU(object):
                                    data_or_wLength=[]);  #Zero length.
         # Execution.
         print self.get_status();
-        
-        
+
+
         print "The device is now executing its application.";
         print "This will result in a USB disconnect.";
         return True;
@@ -175,28 +175,28 @@ class DFU(object):
         #Option byte address.
         adr=0x1fffc000;
         self.setaddresspointer(adr);
-        
+
         # #Grab the old block.
         # data=self.upload(2,2);
         # #Second read verifies the state.
         # status, timeout, state, discarded = dfu.get_status()
         # print state;
         # assert state==State.dfuUPLOAD_IDLE
-        
-        
+
+
         # print "Grabbing old option bytes.";
         # for foo in data:
         #     print "%02x" % foo;
-        
+
         #Write the new block.
         #self._device.ctrl_transfer(0x21, Request.DNLOAD, 2, 0, [0xFF, 0xAA, 0x00, 0x55])
         self.download(2,[0xFF,0xFF]);
-        
+
         #status check causes the write
         status, timeout, state, discarded = dfu.get_status()
         assert state==State.dfuDNBUSY;
-            
-        
+
+
     def readunprotect(self):
         """Mass erase all of Flash memory.  OTP left intact."""
         self._device.ctrl_transfer(bmRequestType=0x21,
@@ -204,27 +204,27 @@ class DFU(object):
                                            wValue=0,
                                            wIndex=0,
                                            data_or_wLength=[0x92]);
-        
+
         print "Unprotecting the device.";
         print "This will cause a USB disconnection.";
         status=self.get_status();
-        
+
         return True;
-        
-        
+
+
     def upload(self, block_number, length):
         # 2 to 2048 byte size for Flash, RAM, and System memory.
         # option bytes should be equal to option byte block size.
         # Other locations defined in Important Considerations in AN2606
-        
-        #Address_Pointer is expected to have been already set by 
+
+        #Address_Pointer is expected to have been already set by
         #Address = ((wBlockNum - 2) * wTransferSize) + Address_Pointer,
-        
+
         #print "Requesting block 0x%08x size %06x" % (block_number,length);
-        
+
         if block_number>0xFFFF:
             print "WARNING: Block 0x%04x will be returned instead. (16-bit addr.)" % (block_number&0xFFFF);
-        
+
         #data = self._device.ctrl_transfer(0xA1, Request.UPLOAD, block_number, 0, length)
         data = self._device.ctrl_transfer(bmRequestType=0xA1,
                                           bRequest=Request.UPLOAD,
@@ -234,13 +234,13 @@ class DFU(object):
         return data
     def setaddresspointer(self, address=application_offset):
         """Sets the address pointer in the STM32."""
-        
+
         byte0=address&0xFF;
         byte1=(address>>8)&0xFF;
         byte2=(address>>16)&0xFF;
         byte3=(address>>24)&0xFF;
-        
-        
+
+
         data=[0x21,                     #Set pointer op-code
               byte0,byte1,byte2,byte3   #Address, little-endian.
               ];
@@ -252,11 +252,11 @@ class DFU(object):
                                            data_or_wLength=data);
         # Address isn't set until first GETSTATUS query.
         status=self.get_status();
-        
+
         # Second query is needed to check if correctly set.
         # Failures result in dfuERROR or errTARGET.
         status=self.get_status();
-        
+
         if status[2]==State.dfuDNLOAD_IDLE:
             print "Setting address pointer to 0x%08x." % address;
             #This will get us back to the entry point.
@@ -265,7 +265,7 @@ class DFU(object):
             print "Failed to set address pointer.";
             return False;
         return True;
-        
+
     def get_status(self):
         status_packed = self._device.ctrl_transfer(0xA1, Request.GETSTATUS, 0, 0, 6)
         status = struct.unpack('<BBBBBB', status_packed)
@@ -296,7 +296,7 @@ class DFU(object):
             State.dfuMANIFEST_WAIT_RESET: self._wait,
             State.dfuIDLE: self._wait
         }
-        
+
         while True:
             state = self.get_state()
             if state == State.dfuIDLE:
@@ -310,28 +310,28 @@ class DFU(object):
 def download(dfu, data, flash_address):
     #block_size = 1 << 8
     sector_size = 1 << 12
-    
+
     print "Flashing to 0x%08x" % flash_address;
-    
+
     base_address=flash_address;
-    
+
     #Rebase the address pointer.
     if not dfu.setaddresspointer(base_address):
         print "Failed to set address."
         sys.exit(1);
-    
+
     flash_address= flash_address+block_size*2-base_address  #Correct offset.
-    
-    
+
+
     if flash_address & (sector_size - 1) != 0:
         raise Exception('Download must start at flash sector boundary')
 
     block_number = flash_address / block_size
     assert block_number * block_size == flash_address
 
-    
+
     print "Based from  0x%08x" % base_address;
-    
+
     try:
         while len(data) > 0:
             packet, data = data[:block_size], data[block_size:]
@@ -340,15 +340,15 @@ def download(dfu, data, flash_address):
                 packet += '\xFF' * (block_size - len(packet))
             #print "Downloading block %i." % block_number;
             dfu.download(block_number, packet)
-            
+
             #status check causes the write
             status, timeout, state, discarded = dfu.get_status()
             assert state==State.dfuDNBUSY;
-            
+
             #Second read verifies the state.
             status, timeout, state, discarded = dfu.get_status()
             assert state==State.dfuDNLOAD_IDLE
-            
+
             sys.stdout.write('.')
             sys.stdout.flush()
             block_number += 1
@@ -358,18 +358,18 @@ def download(dfu, data, flash_address):
 
 def upload(dfu, flash_address, length, path):
     """Uploads a region from the chip to a file on the workstation."""
-    
+
     #Set the base address, then make it zero.
     base_address=flash_address;
     #flash_address=base_address;
-    
+
     #Rebase the address pointer.
     if not dfu.setaddresspointer(base_address):
         print "Failed to set address."
         sys.exit(1);
-    
+
     flash_address= flash_address+block_size*2-base_address  #Correct offset.
-    
+
     if flash_address & (block_size - 1) != 0:
         raise Exception('Upload must start at block boundary')
 
@@ -383,7 +383,7 @@ def upload(dfu, flash_address, length, path):
     print "block_size    = %08x" % block_size;
 
     f = open(path, 'wb')
-   
+
     try:
         while length > 0:
             data = dfu.upload(block_number, block_size)
@@ -487,11 +487,11 @@ if __name__ == '__main__':
                 f = open(sys.argv[2], 'rb')
                 data = f.read()
                 f.close()
-                
+
                 dfu = init_dfu()
                 firmware = data
                 application_offset=int(sys.argv[3],16);
-                
+
                 download(dfu, firmware, application_offset)
                 print('Write complete')
             elif sys.argv[1]=='writeflash':
@@ -499,10 +499,10 @@ if __name__ == '__main__':
                 f = open(sys.argv[2], 'rb')
                 data = f.read()
                 f.close()
-                
+
                 dfu = init_dfu()
                 firmware = data
-                
+
                 download(dfu, firmware, application_offset)
                 print('Write complete')
             elif sys.argv[1]=='writeram':
@@ -510,13 +510,13 @@ if __name__ == '__main__':
                 f = open(sys.argv[2], 'rb')
                 data = f.read()
                 f.close()
-                
+
                 dfu = init_dfu()
                 firmware = data
-                
+
                 download(dfu, firmware, 0x20002000)
                 print('Write complete')
-            
+
             elif sys.argv[1] == 'detach':
                 import usb.core;
                 dfu = init_dfu();


### PR DESCRIPTION
Some basic PEP8 cleanup for the python files as a first pass.  Future pull-requests will be made for further cleanup.