### PR TITLE
Add OSX Build Environment Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ is under development for Android.
 * [SUSE](docs/suse.md)
 * [Raspberry Pi](docs/raspi.md)
 * [Windows](docs/windows.md)
+* [MacOS](docs/macos.md)
 
 ###Additional steps for linux based installations###
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,20 @@
+# MacOS  specifics #
+
+## Preparing build environment ##
+
+####With Homebrew:####
+
+    brew update
+    brew upgrade
+    brew install binutils libusb
+    brew cask install gcc-arm-embedded # This is where you get the arm cross-compiling stuff
+    sudo pip2 install pyusb
+
+####Fix the environment statements:####
+
+The scripts look for python2, but you likely just have that installed as (system) python. Hence:
+
+    sudo ln -s /usr/bin/python /usr/bin/python2
+
+After this, `make flash` as expected.
+  

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -7,7 +7,7 @@
     brew update
     brew upgrade
     brew install binutils libusb
-    brew cask install gcc-arm-embedded # This is where you get the arm cross-compiling stuff
+    brew cask install gcc-arm-embedded # This is where you get the ARM cross-compiling stuff
     sudo pip2 install pyusb
 
 ####Fix the environment statements:####


### PR DESCRIPTION
Nothing spectacularly difficult, but I thought it would be nice to let MacOS users know that yes, they, too, can compile md380tools.