### PR TITLE
Add curl retry persistence to help with sluggish network connectivity

### DIFF
--- a/db/Makefile
+++ b/db/Makefile
@@ -31,22 +31,22 @@ dmrmarc2.tmp: dmrmarc.tmp
 	awk -F, -f insert_nick.awk <$< >$@
 	
 dmrmarc.tmp:
-	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' | perl -pe 's,<br/>,,' >$@
+	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' | perl -pe 's,<br/>,,' >$@
 	
 reflector.tmp:
-	curl -L -f 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@
+	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@
 		
 special.tmp:
 	python2 get_special_IDs.py
 	
 users.json:
-	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=json&header=0' >$@
+	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=json&header=0' >$@
 
 repeaters.json:
-	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=json&header=0' >$@
+	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=json&header=0' >$@
 
 repeaters.csv:
-	curl -L -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=csv&header=0' | perl -pe 's,<BR/>,,' >$@
+	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=csv&header=0' | perl -pe 's,<BR/>,,' >$@
 
 # not used
 bmgroups.json:


### PR DESCRIPTION
Add options on curl for user.bin downloads to help avoid empty downloads
on fail.  Seems to help recover when on 3G/4G LTE links with latency
issues.

Users seem to get 0 byte downloads of dmrmarc.tmp mostly, and not much UI to tell them what happened.

First I changed out curl for wget, which immediately worked when curl was failing... however let's use retry switches on curl first:

```
timeout 8 wget "http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0" -O ~/md380tools/db/retry.tmp

 cat ~/md380tools/db/retry.tmp | perl -pe 's,<br/>,,' >~/md380tools/db/dmrmarc.tmp
```

Warren Merkel, KD4Z