### PR TITLE
Increase sanity check on userdb size for find_dmr_user() to 5 MB

### DIFF
--- a/applet/src/usersdb.c
+++ b/applet/src/usersdb.c
@@ -121,8 +121,10 @@ static int find_dmr_user(char *outstr, int dmr_search, const char *data, int out
 {
     const long datasize = getfirstnumber(data);
 
-    if (datasize == 0 || datasize > 3279629)  // filesize @ 20160420 is 2279629 byte
-       return(0);
+    if (datasize == 0 || datasize > 5242879)  // 5 Meg sanity limit
+       // filesize @ 20160420 is 2279629 bytes
+       //          @ 20170213 is 2604591 bytes
+    return(0);
 
     const char *data_start = next_line_ptr(data);
     const char *data_end = data_start + datasize; // exclusive

--- a/applet/src/usersdb.c
+++ b/applet/src/usersdb.c
@@ -121,10 +121,10 @@ static int find_dmr_user(char *outstr, int dmr_search, const char *data, int out
 {
     const long datasize = getfirstnumber(data);
 
+    // filesize @ 20160420 is 2279629 bytes
+    //          @ 20170213 is 2604591 bytes
     if (datasize == 0 || datasize > 5242879)  // 5 Meg sanity limit
-       // filesize @ 20160420 is 2279629 bytes
-       //          @ 20170213 is 2604591 bytes
-    return(0);
+       return(0);
 
     const char *data_start = next_line_ptr(data);
     const char *data_end = data_start + datasize; // exclusive


### PR DESCRIPTION
To avoid "ID unknown" message when userdb is over 3279629 bytes.

My post build processing is now reaching past this limit, due to first
name substitution into the now missing "nickname" field from dmr-marc.
This shows up in the Firstname field of the display.  Makes all lookups pretty.

Discussion: Was there anything magic about the prior value of 3279629?
It doesn't look like anything lives above that boundary, all the way to
top.

Warren, KD4Z