### PR TITLE
Fixed ability to enable/disable backlight with sidekey

### DIFF
--- a/applet/src/irq_handlers.c
+++ b/applet/src/irq_handlers.c
@@ -145,7 +145,7 @@ void SysTick_Handler(void)
   
 {
   uint32_t dw;
-#if( CONFIG_DIMMED_LIGHT ) // simple GPIO "bit banging", min PWM pulse with = one 'SysTick' period. 
+#if( CONFIG_DIMMED_LIGHT ) // simple GPIO "bit banging", min PWM pulse with = one 'SysTick' period.
   // [in] global_addl_config.backlight_intensities : can be edited (sort of..) in applet/src/menu.c
   uint8_t intensity = global_addl_config.backlight_intensities; // bits 3..0 for IDLE, bits 7..4 for ACTIVE intensity
 #endif  // CONFIG_DIMMED_LIGHT ?
@@ -189,7 +189,7 @@ void SysTick_Handler(void)
      // > the TX pin is at high level.   (YHF: .. which would turn the backlight ON)
      // Thus, when sending NOTHING, the backlight would have MAXIMUM brightness,
      //  -> UART transmit data register must be continuously 'flooded' with data.
-     if( intensity == 0 )  // backlight shall be COMPLETELY DARK ->
+     if( intensity == 0 || kb_backlight)  // backlight shall be COMPLETELY DARK ->
       { // Reconfigure PC6 as 'GPIO' to turn the backlight COMPLETELY off .
         // Two bits in "MODER" per pin : 00bin for GPI,  01bin for GPO, 10bin for 'alternate function mode'.
         GPIOC->MODER = (GPIOC->MODER & ~( 3 << (6/*pin*/ * 2))) |  ( 1 << (6/*pin*/ * 2) ) ;

--- a/applet/src/irq_handlers.h
+++ b/applet/src/irq_handlers.h
@@ -44,6 +44,8 @@
 extern uint8_t GFX_backlight_on; // 0="off" (low intensity), 1="on" (high intensity) 
 //   (note: GFX_backlight_on is useless, as long as no-one calls gfx.c : 
 
+extern uint8_t kb_backlight;
+
 void IRQ_Init(void); // details in the implementaion ( irq_handlers.c )
 
 

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -194,7 +194,11 @@ void evaluate_sidekey ( int button_function)							//This is where new functions
 	switch ( button_function ) {										//We will start at 0x50 to avoid conflicting with any added functions by Tytera.
 		case 0x50 :														//Toggle backlight enable pin to input/output. Disables backlight completely.
 		{
-			GPIOC->MODER = GPIOC->MODER ^ (((uint32_t)0x01) << 12);
+			#if (CONFIG_DIMMED_LIGHT)									//If backlight dimmer is enabled, we will use that instead.
+				kb_backlight ^= 0x01;
+			#else
+				GPIOC->MODER = GPIOC->MODER ^ (((uint32_t)0x01) << 12);
+			#endif
 			reset_backlight();
 			break;
 		}

--- a/applet/src/keyb.h
+++ b/applet/src/keyb.h
@@ -15,6 +15,8 @@ extern "C" {
 
 void f_4101();
 
+uint8_t kb_backlight;
+
 #if defined(FW_D13_020) || defined(FW_S13_020)
 extern uint8_t kb_keycode;
 extern uint8_t kb_keypressed;


### PR DESCRIPTION
Fixed the ability to enable/disable backlight with a programmable sidekey

In reference to issue #693