### PR TITLE
added menu option to set the talkgroup

### DIFF
--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -1307,6 +1307,9 @@ void create_menu_entry_set_tg_screen_store(void)
     extern void draw_zone_channel(); // TODO.
     draw_zone_channel();
 
+    md380_menu_id = md380_menu_id - 1;
+    md380_menu_depth = md380_menu_depth - 1;
+
 #ifdef CONFIG_MENU
     md380_create_menu_entry(md380_menu_id, md380_menu_edit_buf, MKTHUMB(md380_menu_entry_back), MKTHUMB(md380_menu_entry_back), 6, 1, 1);
 #endif

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -1239,7 +1239,7 @@ void create_menu_entry_edit_dmr_id_screen(void)
 
 
 
-    // clear retrun buffer //  see 0x08012a98
+    // clear return buffer //  see 0x08012a98
     // TODO: is wchar_t (16 bits))
     for (i = 0; i < 0x11; i++) {
         p = (uint8_t *) mn_editbuffer_poi;
@@ -1304,6 +1304,9 @@ void create_menu_entry_set_tg_screen_store(void)
     contact.id_h = (new_tx_id>>16) & 0xFF ;
     contact.type = CONTACT_GROUP ;
 
+    wchar_t *p = (void*)contact.name ;
+    snprintfw( p, 16, "TG %d*", new_tx_id );
+
     extern void draw_zone_channel(); // TODO.
     draw_zone_channel();
 
@@ -1337,7 +1340,7 @@ void create_menu_entry_set_tg_screen(void)
 		p = p + i;
 		*p = 0;
 	}
-	//extern int rst_dst ;
+	//load current tg into edit buffer ;
 	current_tg = (int) contact.id_h ;
     current_tg = (current_tg<<8) + (int) contact.id_m;
     current_tg = (current_tg<<8) + (int) contact.id_l;


### PR DESCRIPTION
Intent of the changes:
    Allow the operator to enter an arbitrary talkgroup number, and replace the talkgroup for the current channel with the entry.  This allows arbitrary talkgroups to be joined on Brandmeister and similar repeaters.  In contrast, using the "manual dial" functionality in the baseline firmware's menu allows only private calls.  To join a talkgroup, the destination id must be a group id.  This modification accomplishes that.

Implementation:
Two new functions in menu.c:
    void create_menu_entry_set_tg_screen_store(void)
    void create_menu_entry_set_tg_screen(void)

These functions add a new menu item to set the talkgroup of the current channel using numeric entry.  The code is mostly copied from the edit_dmr_id functions, but the entry is placed into the appropriate nibbles of the extern contact structure.  Writing to the appropriate tg address is accomplished using a copy of the code from the copy_dst_to_contact() function in keyb.c.

The current talkgroup is loaded into the edit buffer.  A change must be confirmed then the new talkgroup is loaded for use.

I am happy to accept any comments regarding the form or function of this code.

Thanks for the opportunity to contribute to this project.

73,

K0BJR