### PR TITLE
Remove `python-usb` package from list

### DIFF
--- a/docs/raspi.md
+++ b/docs/raspi.md
@@ -8,7 +8,7 @@
 Tested on 2016-05-10-raspbian-jessie by IZ2XBZ
 
 sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 \
-             libnewlib-arm-none-eabi python-usb make curl
+             libnewlib-arm-none-eabi make curl
 
 sudo pip install pyusb -U
 ```


### PR DESCRIPTION
The `python-usb` package included in debian is very old. `pip` does not always overwrite the system package and will result in errors when trying to flash the device if there are conflicts.