### PR TITLE
Makefile fixes and improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,16 @@ version.h
 /annotations/d13.020/listing.txt
 /annotations/d13.020/listing.htm
 
+# blhooks program
+/hooks/blhook
+
+# leaflet stuff
+/leaflet/leaflet.aux
+/leaflet/leaflet.pdf
+
+# locales stuff
+/locales/localize
+
 # user/repeater lists
 /db/users.csv
 /db/repeaters.csv
@@ -85,3 +95,7 @@ version.h
 
 # firmware downloads
 firmware/dl
+
+# temporary symbols output
+/symbols/symbols_*
+/symbols/symgrate

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 RELEASE=dist/md380tools-`date "+%Y-%m-%d"`
 
-.PHONY: dist
+.PHONY: dist all
 
 all: image_D13
 
@@ -139,7 +139,7 @@ dbg:
 	@echo MAKE: '${MAKE}'
 	@echo ________
 	@echo AWK version
-	-awk -V
+	-awk -Wversion 2>/dev/null || awk --version
 	@echo ________
 	@echo Make version
 	make -v

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,3 +1,8 @@
+ifeq ($(MAKE_VERSION),3.81)
+OPT = download
+else
+endif
+
 all: unwrapped/D002.032.img unwrapped/S013.020.img unwrapped/D013.020.img unwrapped/D003.020.img
 	
 clean:
@@ -6,5 +11,5 @@ clean:
 download: 
 	"${MAKE}" -f Makefile_orig download
 	
-unwrapped/%.img:
+unwrapped/%.img: $(OPT)
 	"${MAKE}" -f Makefile_orig $@

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,31 +1,10 @@
-
-ifeq ($(MAKE_VERSION),3.81)
-OPT = download
-else
-endif
-
-
-all: unwrapped/D002.032.img unwrapped/S013.020.img unwrapped/D013.020.img
-	
-show:
-	echo $(MAKE_VERSION)
+all: unwrapped/D002.032.img unwrapped/S013.020.img unwrapped/D013.020.img unwrapped/D003.020.img
 	
 clean:
 	"${MAKE}" -f Makefile_orig clean
 	
 download: 
-	echo $(MAKE_VERSION)
 	"${MAKE}" -f Makefile_orig download
 	
-unwrapped/D002.032.img: $(OPT) 
-	"${MAKE}" -f Makefile_orig unwrapped/D002.032.img
-	
-unwrapped/S013.020.img: $(OPT) 
-	"${MAKE}" -f Makefile_orig unwrapped/S013.020.img
-	
-unwrapped/D013.020.img: $(OPT) 	
-	"${MAKE}" -f Makefile_orig unwrapped/D013.020.img
-	
-unwrapped/D003.020.img: $(OPT) 	
-	"${MAKE}" -f Makefile_orig unwrapped/D003.020.img
-	
+unwrapped/%.img:
+	"${MAKE}" -f Makefile_orig $@

--- a/firmware/Makefile_orig
+++ b/firmware/Makefile_orig
@@ -17,7 +17,13 @@ DLFILES := $(addprefix $(DLDIR)/,$(shell grep -v '^\#' firmware_files.txt | awk 
 BINARIES := $(addprefix $(BINDIR)/,$(patsubst %.zip,%.bin,$(notdir $(DLFILES))))
 UNWRAPPEDFILES := $(addprefix $(UNWRAPDIR)/,$(patsubst %.bin,%.img,$(notdir $(BINARIES))))
 
-.PHONY: all download binary unwrap clean cleanall
+FIRMWARE_FILENAME = $$(cat firmware_files.txt | grep "^$(notdir $@)" | cut -f1)
+FIRMWARE_URL      = $$(cat firmware_files.txt | grep "^$(notdir $@)" | cut -f2)
+FIRMWARE_ZIPPATH  = $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f3)
+FIRMWARE_FILESIZE = $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f4)
+FIRMWARE_SHA256   = $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f5)
+
+.PHONY: all binary unwrap clean
 
 all: download binary unwrap
 
@@ -27,9 +33,6 @@ unwrap: $(UNWRAPPEDFILES)
 
 clean:
 	rm -rf $(BINDIR) $(UNWRAPDIR) $(DLDIR)
-
-cleanall: clean
-	rm -rf $(DLDIR)
 
 $(DLDIR):
 	mkdir -p $@
@@ -42,19 +45,16 @@ $(UNWRAPDIR)/%.img: $(BINDIR)/%.bin | $(UNWRAPDIR)
 	../md380-fw --unwrap $< $@
 
 $(BINDIR)/%.bin: $(DLDIR)/%.zip | $(BINDIR)
-	unzip -p $< "$$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f3)" >$@
-	@test $$(find $@ -size $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f4)c) || (rm -f $@ && echo "$@: filesize mismatch" && false)
-	@test $$(shasum -a 256 $@ | awk '{print $$1}') "=" $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f5) || (rm -f $@ && echo "$@: SHA256 mismatch" && false)
-
+	unzip -p $< "$(FIRMWARE_ZIPPATH)" >$@
+	@test $$(find $@ -size $(FIRMWARE_FILESIZE)c) || (rm -f $@ && echo "$@: filesize mismatch" && false)
+	@test $$(shasum -a 256 $@ | awk '{print $$1}') "=" $(FIRMWARE_SHA256) || (rm -f $@ && echo "$@: SHA256 mismatch" && false)
 
 $(BINDIR)/%.bin: $(DLDIR)/%.bin | $(BINDIR)
 	cp $< $@
-	@test $$(find $@ -size $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f4)c) || (rm -f $@ && echo "$@: filesize mismatch" && false)
-	@test $$(shasum -a 256 $@ | awk '{print $$1}') "=" $$(cat firmware_files.txt | grep "^$(basename $(notdir $@))" | cut -f5) || (rm -f $@ && echo "$@: SHA256 mismatch" && false)
+	@test $$(find $@ -size $(FIRMWARE_FILESIZE)c) || (rm -f $@ && echo "$@: filesize mismatch" && false)
+	@test $$(shasum -a 256 $@ | awk '{print $$1}') "=" $(FIRMWARE_SHA256) || (rm -f $@ && echo "$@: SHA256 mismatch" && false)
 
 $(DLDIR)/%: | $(DLDIR)
-	which curl >>/dev/null #Check that we have curl.
-	-echo *
-	-cat firmware_files.txt
-	-echo $$(cat firmware_files.txt | grep "^$(notdir $@)" | cut -f2)
-	curl -f -L $$(cat firmware_files.txt | grep "^$(notdir $@)" | cut -f2) -o $@
+	@which curl >>/dev/null #Check that we have curl.
+	@-echo $(FIRMWARE_URL) \=\> $@
+	@curl -s -f -L $(FIRMWARE_URL) -o $@

--- a/symbols/Makefile
+++ b/symbols/Makefile
@@ -1,34 +1,32 @@
+.SECONDEXPANSION:
+
 UNWRAPPED=../firmware/unwrapped
-#GOLD=../firmware/unwrapped/D002.032.img
 GOLD=../firmware/unwrapped/D013.020.img
 GOLDSYM=../applet/src/symbols_d13.020
+TEST=../firmware/unwrapped/D002.032.img
+
+mangle = $(shell echo $(1) | sed -r "s/symbols_(.)(..)_(...)/\u\10\2\.\3\.img/")
+
+.PHONY: all clean imageclean run test
 
 all: symgrate run
 
 clean:
 	rm -f symgrate symbols_*
-images:
-	cd ../firmware && "${MAKE}" all
+
+$(UNWRAPPED)/%:
+	cd ../firmware && "${MAKE}" unwrapped/$*
 
 symgrate: symgrate.c
 	cc -std=c99 symgrate.c -o symgrate
 
-test: all images
-	./symgrate $(GOLD) $(UNWRAPPED)/D002.034.img <$(GOLDSYM)
+test: all $(GOLD) $(TEST) $(GOLDSYM)
+	./symgrate $(GOLD) $(TEST) <$(GOLDSYM)
 
-run: symgrate images
-	./symgrate $(GOLD) $(UNWRAPPED)/D002.034.img <$(GOLDSYM) >symbols_d02_034
-	./symgrate $(GOLD) $(UNWRAPPED)/D003.008.img <$(GOLDSYM) >symbols_d03_008
-	./symgrate $(GOLD) $(UNWRAPPED)/D003.020.img <$(GOLDSYM) >symbols_d03_020
-	./symgrate $(GOLD) $(UNWRAPPED)/D013.009.img <$(GOLDSYM) >symbols_d13_009
-	./symgrate $(GOLD) $(UNWRAPPED)/S003.012.img <$(GOLDSYM) >symbols_s03_012
-	./symgrate $(GOLD) $(UNWRAPPED)/S013.012.img <$(GOLDSYM) >symbols_s13_012
-	./symgrate $(GOLD) $(UNWRAPPED)/D013.014.img <$(GOLDSYM) >symbols_d13_014
-	./symgrate $(GOLD) $(UNWRAPPED)/S013.020.img <$(GOLDSYM) >symbols_s13_020
-	./symgrate $(GOLD) $(UNWRAPPED)/D013.020.img <$(GOLDSYM) >symbols_d13_020
-	wc -l symbols_*
+symbols_%: $(UNWRAPPED)/$$(call mangle,symbols_%) symgrate $(GOLD) $(GOLDSYM)
+	./symgrate $(GOLD) $(UNWRAPPED)/$(call mangle,symbols_$*) <$(GOLDSYM) >$@
+
+run: symbols_d02_034 symbols_d03_008 symbols_d03_020 symbols_d13_009 symbols_s03_012 symbols_s13_012 symbols_d13_014 symbols_s13_020 symbols_d13_020 
+	@wc -l symbols_*
 	@echo "These are temporary symbol files that will be overwritten."
 	@echo "Move them elsewhere before editing."
-
-
-


### PR DESCRIPTION
I noticed that some of the subdirs would not build properly. While digging into that, I noticed several places where improvements could be made to the makefiles themselves.

Highlights:

* Fixed awk version issue in make debug
* Added more intermediate files to .gitignore
* Added implicit rules to reduce ongoing maintenance
* Reduced duplication of logic in firmware/Makefile_orig
* Flagged additional rules as .PHONY