### PR TITLE
Fix for issue #712, cleanup of keyb.

### DIFF
--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -35,6 +35,7 @@ uint8_t kb_backlight=0; // flag to disable backlight via sidekey.
 // 8 = rearm
 // 0 = none pressed
 
+
 #if defined(FW_D13_020) || defined(FW_S13_020)
 inline int get_main_mode()
 {
@@ -116,70 +117,70 @@ void handle_hotkey( int keycode )
     reset_backlight();
     
     switch( keycode ) {
-        case 0 :
-	    clog_redraw();
+        case KC_0 :
+            clog_redraw();
             switch_to_screen(6);
             break ;
-        case 1 :
+        case KC_1 :
             sms_test();
             break ;
-        case 2 :
-	    slog_redraw();
+        case KC_2 :
+            slog_redraw();
             switch_to_screen(5);
             break ;
-        case 3 :
+        case KC_3 :
             copy_dst_to_contact();
             break ;
-        case 4 :
-	    lastheard_redraw();
+        case KC_4 :
+            lastheard_redraw();
             switch_to_screen(4);
             break ;
-        case 5 :
+        case KC_5 :
             syslog_clear();
-	    lastheard_clear();
-	    slog_clear();
-	    clog_clear();
-	    nm_started = 0;	// reset nm_start flag used for some display handling
-	    nm_started5 = 0;	// reset nm_start flag used for some display handling
-	    nm_started6 = 0;	// reset nm_start flag used for some display handling
+            lastheard_clear();
+            slog_clear();
+            clog_clear();
+            nm_started = 0;	// reset nm_start flag used for some display handling
+            nm_started5 = 0;	// reset nm_start flag used for some display handling
+            nm_started6 = 0;	// reset nm_start flag used for some display handling
             break ;
-        case 6 :
-        {
-            static int cnt = 0 ;
-            syslog_printf("=dump %d=\n",cnt++);
-        }
+        case KC_6 :
+            {
+                static int cnt = 0 ;
+                syslog_printf("=dump %d=\n",cnt++);
+            }
             syslog_dump_dmesg();
             break ;
-        case 7 :
+        case KC_7 :
             bp_send_beep(BEEP_TEST_1);
             nm_screen = 0 ;
             // cause transient.
             gui_opmode2 = OPM2_MENU ;
             gui_opmode1 = SCR_MODE_IDLE | 0x80 ;
             break ;
-        case 8 :
+        case KC_8 :
             bp_send_beep(BEEP_TEST_2);
             switch_to_screen(1);
             break ;
-        case 9 :
+        case KC_9 :
             bp_send_beep(BEEP_TEST_3);
             switch_to_screen(2);
             break ;
-        case 11 :
+        case KC_UP :
             //gui_control(1);
             //bp_send_beep(BEEP_9);
             //beep_event_probe++ ;
             //sms_test2(beep_event_probe);
             //mb_send_beep(beep_event_probe);
             break ;
-        case 12 :
+        case KC_DOWN :
             //gui_control(241);
             //bp_send_beep(BEEP_25);
             //beep_event_probe-- ;
             //sms_test2(beep_event_probe);
             //mb_send_beep(beep_event_probe);
             break ;
-        case 15 :
+        case KC_OCTOTHORPE :
             syslog_redraw();
             switch_to_screen(3);
             break ;
@@ -261,22 +262,22 @@ inline int is_intercept_allowed()
     }
 }
 
-inline int is_intercepted_keycode( int kc )
+inline int is_intercepted_keycode( uint8_t kc )
 {
     switch( kc ) {
-        case 0 :
-        case 1 :
-        case 2 :
-        case 3 :
-        case 4 :
-        case 5 :
-        case 6 :
-        case 7 :
-        case 8 :
-        case 9 :
-        case 11 :
-        case 12 :
-        case 15 :
+        case KC_0 :
+        case KC_1 :
+        case KC_2 :
+        case KC_3 :
+        case KC_4 :
+        case KC_5 :
+        case KC_6 :
+        case KC_7 :
+        case KC_8 :
+        case KC_9 :
+        case KC_UP :
+        case KC_DOWN :
+        case KC_OCTOTHORPE :
             return 1 ;
         default:
             return 0 ;
@@ -300,7 +301,7 @@ void kb_handler_hook()
     // allow calling of menu during qso.
     // not working correctly.
     if( global_addl_config.experimental ) {
-        if( (kp & 2) == 2 ) {
+        if( (kp & 3) == 3 ) {
             if( gui_opmode2 != OPM2_MENU ) {
                 gui_opmode2 = OPM2_MENU ;
                 gui_opmode1 = SCR_MODE_IDLE | 0x80 ;

--- a/applet/src/keyb.h
+++ b/applet/src/keyb.h
@@ -12,6 +12,24 @@
 extern "C" {
 #endif
 
+typedef enum {
+	KC_0 = 0,
+	KC_1 = 1,
+	KC_2 = 2,
+	KC_3 = 3,
+	KC_4 = 4,
+	KC_5 = 5,
+	KC_6 = 6,
+	KC_7 = 7,
+	KC_8 = 8,
+	KC_9 = 9,
+	KC_MENU = 10,
+	KC_UP = 11,
+	KC_DOWN = 12,
+	KC_BACK = 13,
+	KC_ASTERISK = 14,
+	KC_OCTOTHORPE = 15
+} keycode_t;
 
 void f_4101();
 


### PR DESCRIPTION
The reported defect (#712: 'Menu Button Stops Working With Experimental "ON"') was isolated to a change to keyb.c made in commit fdc839e48c71ce9695328ec4c8f3dc0c2b366b20 ("allow calling up the menu induring rx").

The problem is two-fold:
1. The code does not actually work for the stated purpose (as the comment in the commit indicates).
2. The conditional guarding the code allows it to execute outside of the condition it was crafted for (aka: it triggers regardless of the idle/rx state of the radio).

Fixing problem 1 will require more thought.  This commit fixes problem 2 by limiting the execution of this code to when the radio is in the rx state.

While investigating the behavior in this code path, I performed some cleanup in the form of creating symbolic constants for the keycodes.  This reduces the number of magic numbers in the file, but not all of them.