### PR TITLE
Fix for issue #645

### DIFF
--- a/firmware/Makefile_orig
+++ b/firmware/Makefile_orig
@@ -58,3 +58,4 @@ $(DLDIR)/%: | $(DLDIR)
 	@which curl >>/dev/null #Check that we have curl.
 	@-echo $(FIRMWARE_URL) \=\> $@
 	@curl -s -f -L $(FIRMWARE_URL) -o $@
+	@test $$(find $@ -size +0c) || (rm -f $@ && echo "FATAL ERROR: $@ downloaded as a zero byte file" && false)


### PR DESCRIPTION
This is the minimal fix for issue #645 .  Before this fix, there were only two places where a corrupted file could show up:
1. From a curl download that fails without an error code
2. md380-fw generating a corrupted file

The other recipes in the firmware directory all check the size of the target and delete it and fail if there is a mismatch.  This minimal fix fills gap number 1 from above with a simple check for greater than zero bytes.