### PR TITLE
Changed ci to error on compiler warnings

### DIFF
--- a/applet/Makefile
+++ b/applet/Makefile
@@ -4,7 +4,7 @@ MKLISTING=1
 FW ?= D13_020
 
 ifeq (,$(wildcard mark.tmp))
-	# not exists
+  # not exists
   PROBLEM=0	
 else
   old_build := $(shell cat mark.tmp)
@@ -93,6 +93,7 @@ ifdef MKLISTING
 CFLAGS += -Wa,-a=$(@:.o=.lst)
 endif
 CFLAGS += -D$(FWDEFINE)	
+CFLAGS += $(CIFLAGS)
 ###################################################
 
 vpath %.c src
@@ -183,7 +184,8 @@ image_D13:
 image_S13:
 	"${MAKE}" FW=S13_020 all  
 
+.PHONY: ci
 ci:
-	"${MAKE}" clean image_D02
-	"${MAKE}" clean image_S13
-	"${MAKE}" clean image_D13
+	"${MAKE}" CIFLAGS="-Werror -Wno-cpp" clean image_D02
+	"${MAKE}" CIFLAGS="-Werror -Wno-cpp" clean image_S13
+	"${MAKE}" CIFLAGS="-Werror -Wno-cpp" clean image_D13


### PR DESCRIPTION
This commit is an attempt to stop the inflow of new warnings being added to the applet, while avoiding having to resolve all the #warning directives already in the codebase.

With this change, regular builds are unaffected; they will proceed as they have in the past.  "make ci", however, will promote warnings to errors, but #warnings will be suppressed altogether.  The end result of this will be to make the ci fail when someone introduces a new warning to the applet.

This commit may warrant the closing of issue #704.