### PR TITLE
Improved resiliency of curl invocations

### DIFF
--- a/curl.mak
+++ b/curl.mak
@@ -1,0 +1,1 @@
+CURL_FLAGS := -s -f -L --retry 5 --max-time 60 --retry-delay 5

--- a/db/Makefile
+++ b/db/Makefile
@@ -1,3 +1,4 @@
+include ../curl.mak
 
 .PHONY: all update clean
 
@@ -31,26 +32,26 @@ dmrmarc2.tmp: dmrmarc.tmp
 	awk -F, -f insert_nick.awk <$< >$@
 	
 dmrmarc.tmp:
-	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' | perl -pe 's,<br/>,,' >$@
+	curl $(CURL_FLAGS) 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' | perl -pe 's,<br/>,,' >$@
 	
 reflector.tmp:
-	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@
+	curl $(CURL_FLAGS) 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@
 		
 special.tmp:
 	python2 get_special_IDs.py
 	
 users.json:
-	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=json&header=0' >$@
+	curl $(CURL_FLAGS) 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=json&header=0' >$@
 
 repeaters.json:
-	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=json&header=0' >$@
+	curl $(CURL_FLAGS) 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=json&header=0' >$@
 
 repeaters.csv:
-	curl -L --retry 5 --max-time 20 --retry-delay 1 -f 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=csv&header=0' | perl -pe 's,<BR/>,,' >$@
+	curl $(CURL_FLAGS) 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=csv&header=0' | perl -pe 's,<BR/>,,' >$@
 
 # not used
 bmgroups.json:
-	curl -L -f 'https://brandmeister.network/dist/js/bm/groups.js' >$@
+	curl $(CURL_FLAGS) 'https://brandmeister.network/dist/js/bm/groups.js' >$@
 	
 
 ci: clean all

--- a/firmware/Makefile_orig
+++ b/firmware/Makefile_orig
@@ -9,6 +9,8 @@
 # to identify accidental corruption.  Anyone causing intentional
 # corruption is politely asked to ensure that their joke is funny.
 
+include ../curl.mak
+
 DLDIR = dl
 BINDIR = bin
 UNWRAPDIR = unwrapped
@@ -57,5 +59,5 @@ $(BINDIR)/%.bin: $(DLDIR)/%.bin | $(BINDIR)
 $(DLDIR)/%: | $(DLDIR)
 	@which curl >>/dev/null #Check that we have curl.
 	@-echo $(FIRMWARE_URL) \=\> $@
-	@curl -s -f -L $(FIRMWARE_URL) -o $@
+	@curl $(CURL_FLAGS) $(FIRMWARE_URL) -o $@
 	@test $$(find $@ -size +0c) || (rm -f $@ && echo "FATAL ERROR: $@ downloaded as a zero byte file" && false)


### PR DESCRIPTION
/curl.mak now centralizes the flags for curl invocations to use.  The flags are a union of what were being used in /db/Makefile and /firmware/Makefile_orig.  Additionally, I increased the max-time and retry-delay based on the discussion with @KD4Z in the thread under PR #745.