### PR TITLE
Website

### DIFF
--- a/md380org/Makefile
+++ b/md380org/Makefile
@@ -1,0 +1,9 @@
+
+
+all: themes site
+
+themes:
+	make -C themes all
+
+server: themes
+	hugo server --buildDrafts

--- a/md380org/Makefile
+++ b/md380org/Makefile
@@ -1,6 +1,7 @@
 
+.PHONY: themes
 
-all: themes site
+all: site
 
 themes:
 	make -C themes all
@@ -8,7 +9,9 @@ themes:
 server: themes
 	hugo server --buildDrafts
 
-site:
+site: themes
 	hugo
 	#Results are in public/
 
+clean:
+	rm -rf public

--- a/md380org/Makefile
+++ b/md380org/Makefile
@@ -7,3 +7,8 @@ themes:
 
 server: themes
 	hugo server --buildDrafts
+
+site:
+	hugo
+	#Results are in public/
+

--- a/md380org/config.toml
+++ b/md380org/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://md380.org/"
 languageCode = "en-us"
 title = "MD380.org"
-theme = "docdock"
+theme = "hugo-theme-docdock"
 
 [output]
 home = [ "HTML", "RSS", "JSON" ]

--- a/md380org/config.toml
+++ b/md380org/config.toml
@@ -1,0 +1,7 @@
+baseURL = "https://md380.org/"
+languageCode = "en-us"
+title = "MD380.org"
+theme = "docdock"
+
+[output]
+home = [ "HTML", "RSS", "JSON" ]

--- a/md380org/content/_index.md
+++ b/md380org/content/_index.md
@@ -1,0 +1,16 @@
+
+# MD380.ORG
+
+Howdy y'all,
+
+This is a quick little work-in-progress website to make MD380Tools,
+the patched firmware for the Tytera MD380, a bit easier to install and
+use.
+
+Development of the firmware will proceed as it always has at
+[travisgoodspeed/md380tools](http://github.com/travisgoodspeed/md380tools/)
+on Github.
+
+--Travis KK4VCZ
+
+

--- a/md380org/content/about.md
+++ b/md380org/content/about.md
@@ -1,0 +1,18 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = true
+title = "About"
+
+[menu.main]
+identifier="About"
+
++++
+
+MD380Tools is a patched firmware distribution for the Tytera MD380.
+It adds support for a number of features including promiscuous mode, a
+CallerID database, USB logging, and Morse code narration.
+
+Source code for our firmware patches is available at
+[travisgoodspeed/md380tools](http://github.com/travisgoodspeed/md380tools/)
+on Github in C, which is patched into what we've reverse engineered of
+the official firmware.

--- a/md380org/content/downloads.md
+++ b/md380org/content/downloads.md
@@ -1,0 +1,21 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = true
+title = "Downloads"
+
+[menu.main]
+identifier="Downloads"
+
++++
+
+Linux users can build and install MD380Tools from our source code at
+[travisgoodspeed/md380tools](http://github.com/travisgoodspeed/md380tools/)
+on Github.  This technique works from inside of a virtual machine, and
+some folks have been able to get it working on Windows as well.
+
+For those who would rather install prebuilt firmware, we offer [daily
+builds](http://md380.org/releases/daily/) which are updated whenever
+our master branch has changed.  These include the manufacturer's
+Windows installer.
+
+

--- a/md380org/content/features.md
+++ b/md380org/content/features.md
@@ -1,0 +1,11 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = false
+title = "Features"
+
+[menu.main]
+identifier="Features"
+
++++
+
+TODO

--- a/md380org/content/features/callerid.md
+++ b/md380org/content/features/callerid.md
@@ -1,0 +1,21 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = false
+title = "Caller ID"
+
+[menu.main]
+parent = "Features"
+identifier = "CallerID"
+
++++
+
+When DMR was first becoming popular, a codeplug circulated with some
+seven hundred of the most popular American users.  Very quickly, that
+became unmaintainable, so MD380Tools allows you to flash a database of
+sixty thousand international users.  When an incoming call arrives,
+you'll see the user's name, callsign and country.
+
+Because this database is separate from your contacts, you can keep
+your contact list nice and small, listing only those folks you intend
+to directly call or text message.
+

--- a/md380org/content/features/calllog.md
+++ b/md380org/content/features/calllog.md
@@ -1,0 +1,18 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = false
+title = "Call Log"
+
+[menu.main]
+parent = "Features"
+identifier = "CallLog"
+
++++
+
+During a busy QSO or net, it can be hard to catch the callsign of
+every participant.
+
+MD380Tools has your back with the CallLog feature, which displays a
+scrolling list of all recent callsigns or DMR IDs.  Just press 4 to
+call up the log, and press 7 to return to the standard desktop.
+

--- a/md380org/content/features/morse.md
+++ b/md380org/content/features/morse.md
@@ -1,0 +1,20 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = true
+title = "Morse Narration"
+
+[menu.main]
+parent = "Features"
+identifier = "Morse"
+
++++
+
+DMR opens up a whole new world of digital ham radio, but it can be a
+bit awkward to use for hams who are unable to see the screen.
+
+MD380Tools solves this with a narration feature that can be enabled
+through the MD380Tools menu.  This narrator will beep station names
+and other on-screen items audibly in Morse code so you can know which
+Zone or Channel is selected without looking at the screen.
+
+

--- a/md380org/content/features/netmon.md
+++ b/md380org/content/features/netmon.md
@@ -1,0 +1,19 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = false
+title = "Network Monitor"
+
+[menu.main]
+parent = "Features"
+identifier = "NetMon"
+
++++
+
+Your radio knows a lot of information about the network that you don't
+need to see every day, but when something goes wrong you'd like to see
+it.  Our Network Monitor features allow you to packet headers, RX and
+transmit frequencies, color codes, and timeslots at the push of a
+button.
+
+Press 8 or 9 at the desktop to see information on the incoming signal,
+while pressing 7 will bring you back to the default screen.

--- a/md380org/content/features/promiscuous.md
+++ b/md380org/content/features/promiscuous.md
@@ -1,0 +1,23 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = false
+title = "Promiscuous Mode"
+
+[menu.main]
+parent = "Features"
+identifier = "Promiscuous"
+
++++
+
+DMR repeaters these days carry a number of talkgroups, but those
+talkgroups are always changing and it can be a pain to constantly
+update to the latest codeplugs, or to merge codeplugs from multiple
+repeaters in your region.
+
+MD380Tools comes to the rescue with Promiscuous Mode.  Enabling this
+optional feature will cause your radio to play audio whenever *any*
+traffic comes in on your selected timeslot.  You can then quickly jot
+down the settings to update your codeplug.
+
+
+

--- a/md380org/content/post/md380org.md
+++ b/md380org/content/post/md380org.md
@@ -1,0 +1,14 @@
++++
+date = "2017-05-13T14:11:36-04:00"
+draft = true
+title = "Introduction MD380.org"
+
++++
+
+Howdy y'all,
+
+After months of procrastination, I've finally stood up a public
+webserver on MD380.org.
+
+--Travis KK4VCZ
+

--- a/md380org/themes/Makefile
+++ b/md380org/themes/Makefile
@@ -1,0 +1,5 @@
+all: hugo-theme-docdock
+hugo-theme-docdock:
+	git clone https://github.com/vjeantet/hugo-theme-docdock
+clean:
+	rm -rf hugo-theme-docdock


### PR DESCRIPTION
Toward #784, this adds a website to the project that is build by Hugo 20.0 or higher.  (Debian/Testing doesn't include such a version, so be sure to install it from the Hugo website.)
