### PR TITLE
Wrap Scrolling of App Menu

### DIFF
--- a/applet/src/amenu_codeplug.c
+++ b/applet/src/amenu_codeplug.c
@@ -261,18 +261,22 @@ int am_cbk_ZoneList(app_menu_t *pMenu, menu_item_t *pItem, int event, int param 
         case 'U' :  // cursor UP
            if(  pSL->focused_item > 0 )
             { --pSL->focused_item;
+            } else // Wrap around top
+            { pSL->focused_item = (pSL->num_items-1);
+            }
 #            if( CONFIG_MORSE_OUTPUT ) // autonomously report the first item in Morse code:
               pMenu->morse_request = AMENU_MORSE_REQUEST_ITEM_TEXT | AMENU_MORSE_REQUEST_ITEM_VALUE;
 #            endif
-            }
            break;
         case 'D' :  // cursor DOWN
            if(  pSL->focused_item < (pSL->num_items-1) )
             { ++pSL->focused_item;
+            } else // Wrap around bottom
+            { pSL->focused_item = 0;
+            }
 #            if( CONFIG_MORSE_OUTPUT ) // autonomously report the first item in Morse code:
               pMenu->morse_request = AMENU_MORSE_REQUEST_ITEM_TEXT | AMENU_MORSE_REQUEST_ITEM_VALUE;
 #            endif
-            }
            break;
         default:    // Other keys .. editing or treat as a hotkey ?
            break;

--- a/applet/src/app_menu.c
+++ b/applet/src/app_menu.c
@@ -834,6 +834,10 @@ int Menu_DrawIfVisible(int caller)
                       { --pMenu->item_index; 
                         // If no other keystrokes follow, and if Morse output is enabled,..:
                         pMenu->morse_request = AMENU_MORSE_REQUEST_ITEM_TEXT | AMENU_MORSE_REQUEST_ITEM_VALUE;
+                      } else {
+                        // Wrap around top of menu
+                        pMenu->item_index = pMenu->num_items - 1;
+                        pMenu->morse_request = AMENU_MORSE_REQUEST_ITEM_TEXT | AMENU_MORSE_REQUEST_ITEM_VALUE;
                       }
                }
               pMenu->redraw = TRUE;
@@ -854,6 +858,10 @@ int Menu_DrawIfVisible(int caller)
                   default: // not "editing" but "navigating" ... 
                      if(pMenu->item_index < (pMenu->num_items-1) )  
                       { ++pMenu->item_index;
+                        pMenu->morse_request = AMENU_MORSE_REQUEST_ITEM_TEXT | AMENU_MORSE_REQUEST_ITEM_VALUE;
+                      } else {
+                        // Wrap around bottom of menu
+                        pMenu->item_index = 0;
                         pMenu->morse_request = AMENU_MORSE_REQUEST_ITEM_TEXT | AMENU_MORSE_REQUEST_ITEM_VALUE;
                       }
                      break;


### PR DESCRIPTION
Wrap scrolling for the app menu. When at the top and pressing up the menu will continue to the bottom. At the bottom, it will wrap to the top. This also wraps the scrolling of the zone chooser in the app menu.