### PR TITLE
Disable Hotkeys When App Menu Is Open

### DIFF
--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -348,7 +348,11 @@ void kb_handler_hook()
         }
     }
 
+#if (CONFIG_APP_MENU)
+    if( is_intercept_allowed() && !Menu_IsVisible() ) {
+#else
     if( is_intercept_allowed() ) {
+#endif
         if( is_intercepted_keycode(kc) ) {
             if( (kp & 2) == 2 ) {
                 kb_keypressed = 8 ;


### PR DESCRIPTION
When the app menu is open this disables the hotkeys. Without this, using the app menu can result in unknowingly transmitting (1 button) or clearing logs (5 button).