### PR TITLE
Fix for backlight and non-functional "red key menu" for KD4Z VM

### DIFF
--- a/applet/src/addl_config.c
+++ b/applet/src/addl_config.c
@@ -76,7 +76,7 @@ void cfg_load()
     memcpy(&global_addl_config,&tmp,tmp.length);
     
     // range limit
-    R(global_addl_config.userscsv,3);			// 2017-02-19	0-disable 1-userscsv 2-talkeralias 3-both
+    R(global_addl_config.userscsv,3);   // 2017-02-19   0-disable 1-userscsv 2-talkeralias 3-both
     R(global_addl_config.micbargraph,1);
     R(global_addl_config.debug,1);
     R(global_addl_config.rbeep,1);
@@ -134,8 +134,8 @@ void cfg_set_radio_name()
 
 void init_global_addl_config_hook(void)
 {
-    LOGB("booting\n");
-    
+    LOGB("t=%d: booting\n", (int)IRQ_dwSysTickCounter ); // 362 SysTicks after power-on
+   
     cfg_load();
 
 //#ifdef CONFIG_MENU

--- a/applet/src/app_menu.c
+++ b/applet/src/app_menu.c
@@ -1660,8 +1660,8 @@ BOOL Menu_CheckLongKeypressToActivateMorse(app_menu_t *pMenu)
      global_addl_config.cw_pitch_10Hz = 65;
      global_addl_config.cw_volume     = 10;  // CW audible even if vol-pot at zero
      global_addl_config.cw_speed_WPM  = 18;
-     LCD_Printf( &dc, "\tMorse Defaults set.\r\r Adjust parameters"\
-                      "\r in the setup menu.\r\r Release key now.\r" );
+     LCD_Printf( &dc, "\tMorse Defaults set.\r\r Adjust parameters\r" );
+     LCD_Printf( &dc, " in the setup menu.\r\r Release key now.\r" );
      LCD_FillRect( 0, dc.y, LCD_SCREEN_WIDTH-1, LCD_SCREEN_HEIGHT-1, dc.bg_color );
      morse_activation_pending = FALSE; // operator made his decision
      LOGB("morse output: default\n");

--- a/applet/src/display.c
+++ b/applet/src/display.c
@@ -418,7 +418,7 @@ int main(void)
 void draw_statusline_hook( uint32_t r0 )
 {
    if( ! (boot_flags & BOOT_FLAG_DREW_STATUSLINE) )
-    { LOGB("draw_statusline\n");
+    { LOGB("t=%d: draw_stat\n", (int)IRQ_dwSysTickCounter ); // 4383(!) SysTicks after power-on
     }
    boot_flags |= BOOT_FLAG_DREW_STATUSLINE;
 

--- a/applet/src/irq_handlers.c
+++ b/applet/src/irq_handlers.c
@@ -1253,6 +1253,11 @@ void SysTick_Handler(void)
 
      // 2017-05-14 : Removed the brightness 'ramp-up' test. 
      // The 9 intensity levels can now be tested in app_menu.c in inc/dec edit mode.
+     // 2017-05-16, reported by KD4Z (not reproducable here yet when compiling on MinGW - DL4YHF) :
+     //  >  Red button no longer opens new menu, and sometimes 
+     //  >  leaves display in full white condition. 
+     //  >  Also, the Backlight will not turn off, 
+     //  >  no matter what settings/timings you choose.
 #   if( CONFIG_DIMMED_LIGHT ) // Support dimmed backlight ?
      if( (backlight_timer>0) || (md380_radio_config.backlight_time==0) )
       { // If the backlight time is ZERO, use the 'radio-active' setting ("backlight level HI")
@@ -1280,7 +1285,7 @@ void SysTick_Handler(void)
      // > the TX pin is at high level.   (YHF: .. which would turn the backlight ON)
      // Thus, when sending NOTHING, the backlight will have MAXIMUM brightness,
      //  -> UART transmit data register must be continuously 'flooded' with data.
-     if( intensity == 0 || kb_backlight )  // backlight shall be COMPLETELY DARK ->
+     if( (intensity==0) || kb_backlight )  // backlight shall be COMPLETELY DARK ->
       { // Reconfigure PC6 as 'GPIO' to turn the backlight COMPLETELY off .
         // Two bits in "MODER" per pin : 00bin for GPI,  01bin for GPO, 10bin for 'alternate function mode'.
         GPIOC->MODER = (GPIOC->MODER & ~( 3 << (6/*pin*/ * 2))) |  ( 1 << (6/*pin*/ * 2) ) ;

--- a/applet/src/irq_handlers.c
+++ b/applet/src/irq_handlers.c
@@ -12,14 +12,13 @@
   Latest modifications:
     2017-05-19, DL4YHF : When building the firmware in KD4Z's VM,
              the patched binary executable wasn't the same as when compiled
-             on another Debian (64-bit) system, and also not the same
-             as when compiled on Windows. The different 'runtime behaviour'
-             caused problems that are hopefully fixed with the new
-             'boot_flags'. Basically, boot_flags is a bitwise combination
-             to find out when we are 'open for business', instead of relying
-             on a certain number of SysTick-interrupts before activating
-             the backlight-PWM, polling keys for the new alternative menu,
-             etc.
+             on another Debian (64-bit) system, or when compiled on Windows. 
+             The different 'runtime behaviour' caused problems that are 
+             hopefully fixed with new 'boot_flags', defined in irq_handlers.h .
+      These boot_flags disable certain function calls shortly after power-on, 
+      and are used here to declare ourselves 'open for business', instead of 
+      simply letting some time pass before activating the backlight-PWM, 
+      the keyboard polling for the new alternative ('red button') menu, etc. 
     
  To include the 'dimmed backlight' feature in the patched firmware:
     
@@ -1242,6 +1241,7 @@ void SysTick_Handler(void)
       }
    }    // end if < backlight (GPIO) not initialized yet ? >   
 
+#if( CAN_POLL_KEYS )
   // TEST: When does Tytera start polling the keyboard, and update kb_row_col_pressed ? 
   if( (kb_row_col_pressed!=0) && !(boot_flags & BOOT_FLAG_FIRST_KEY_PRESSED) )
    { boot_flags |= BOOT_FLAG_FIRST_KEY_PRESSED;
@@ -1249,6 +1249,7 @@ void SysTick_Handler(void)
      // Test result: First key detected 4432 SysTicks after power-on .
      // That's over 6 seconds. Explains why polling keys EARLY didn't work.
    } // end < keyboard-polling-test >
+#endif // CAN_POLL_KEYS ?
 
   if( (boot_flags & ( BOOT_FLAG_INIT_BACKLIGHT | BOOT_FLAG_LOADED_CONFIG | BOOT_FLAG_DREW_STATUSLINE ) )
                  != ( BOOT_FLAG_INIT_BACKLIGHT | BOOT_FLAG_LOADED_CONFIG | BOOT_FLAG_DREW_STATUSLINE ) )

--- a/applet/src/irq_handlers.h
+++ b/applet/src/irq_handlers.h
@@ -72,7 +72,9 @@ extern uint8_t boot_flags; // bitwise combination of the following flags:
 #define BOOT_FLAG_INIT_BACKLIGHT  0x01 // initialized backlight (GPIO) ?
 #define BOOT_FLAG_LOADED_CONFIG   0x02 // called init_global_addl_config_hook() ?
 #define BOOT_FLAG_DREW_STATUSLINE 0x04 // called draw_statusline_hook() ?
-#define BOOT_FLAG_POLLED_KEYBOARD 0x08 // polled the keyboard at least once ?
+#define BOOT_FLAG_OPEN_FOR_BUSINESS 0x08 // set when it's ok to open the app-menu
+#define BOOT_FLAG_FIRST_KEY_POLLED  0x10 // set when keyboard variables are valid
+#define BOOT_FLAG_FIRST_KEY_PRESSED 0x20 // set when kb_row_col_pressed was nonzero for the first time
 
 extern volatile uint32_t IRQ_dwSysTickCounter; // Incremented each 1.5 ms
 

--- a/applet/src/lcd_driver.c
+++ b/applet/src/lcd_driver.c
@@ -665,13 +665,15 @@ int LCD_DrawString( lcd_context_t *pContext, char *cp )
 int LCD_Printf( lcd_context_t *pContext, char *fmt, ... )
   // Almost the same as LCD_DrawString,
   // but with all goodies supported by tinyprintf .
+  // Total length of the output should not exceed 80 characters.
 {
-  char sz127[128];
+  char szTemp[84]; // how large is the stack ? Dare to use more ?
   va_list va;
   va_start(va, fmt);
-  va_snprintf(sz127, 127, fmt, va );    
-  va_end(va);      
-  return LCD_DrawString( pContext, sz127 );
+  va_snprintf(szTemp, sizeof(szTemp)-1, fmt, va );    
+  va_end(va); 
+  szTemp[sizeof(szTemp)-1] = '\0';     
+  return LCD_DrawString( pContext, szTemp );
 } // end LCD_Printf()
 
 


### PR DESCRIPTION
The previous version only worked properly when compiled on a freshly installed 64-bit Debian system, and on 64-bit Windows using MinGW. No other platforms tested here yet.

The previous version failed to open the red menu when compiled in the KD4Z Virtual Machine.

Why these "building platforms" produce different binary code (confirmed by the map file) still has to be found out. Maybe the GNU ARM toolchain behaves differently on 32- and 64-bit systems (hard to believe... but that's what it looked like).

This release has a temporary(!) feature to check if the hooked SysTick handler is invoked in the patched firmware at all:  Between 5 and 20 seconds after power-on, the GREEN LED will give very short (and thus weak) flashes, once every 256 * 1.5 milliseconds. When successfully tested on KD4Z VM, this LED-flashing feature will be removed again (it's in irq_handlers.c, and can be easily commented out when not required anymore).
