### PR TITLE
kludge to get backlight and app-menu running in KD4Z VM

### DIFF
--- a/applet/src/display.c
+++ b/applet/src/display.c
@@ -420,7 +420,7 @@ void draw_statusline_hook( uint32_t r0 )
    if( ! (boot_flags & BOOT_FLAG_DREW_STATUSLINE) )
     { LOGB("t=%d: draw_stat\n", (int)IRQ_dwSysTickCounter ); // 4383(!) SysTicks after power-on
     }
-   boot_flags |= BOOT_FLAG_DREW_STATUSLINE;
+   boot_flags |= BOOT_FLAG_DREW_STATUSLINE; // important for SysTick_Handler to know when we're "open for business" !
 
 # if (CONFIG_APP_MENU)
     // If the screen is occupied by the optional 'red button menu', 

--- a/applet/src/irq_handlers.c
+++ b/applet/src/irq_handlers.c
@@ -1254,9 +1254,14 @@ void SysTick_Handler(void)
   if( (boot_flags & ( BOOT_FLAG_INIT_BACKLIGHT | BOOT_FLAG_LOADED_CONFIG | BOOT_FLAG_DREW_STATUSLINE ) )
                  != ( BOOT_FLAG_INIT_BACKLIGHT | BOOT_FLAG_LOADED_CONFIG | BOOT_FLAG_DREW_STATUSLINE ) )
    { // As long as the original firmware is still "booting",
-     // we cannot poll the keyboard, and should not drive the display.
+     // we cannot poll the keyboard, and should not drive the display....
      IRQ_dwSysTicksAtBoot = IRQ_dwSysTickCounter;
      tdiff = 0;
+     // .... but when compiled in the KD4Z VM, something was missing,
+     //      possibly an improperly hooked function (hook not called), so:
+     if( IRQ_dwSysTickCounter > 6000 )  // <- very ugly kludge (2017-05-20)
+      { boot_flags |= (BOOT_FLAG_INIT_BACKLIGHT | BOOT_FLAG_LOADED_CONFIG | BOOT_FLAG_DREW_STATUSLINE); // heavens, no !
+      }
    }
   else // all necessary functions have been called - really "open for business" ?
    { tdiff = (int)IRQ_dwSysTickCounter - (int)IRQ_dwSysTicksAtBoot;


### PR DESCRIPTION
problem possibly caused by an outdated display.c, but fixed by declaring ourselves "open for business" some seconds after power-on.
See irq_handlers.c, SysTick_Handler .