### PR TITLE
Use ${MAKE} for sub-makes rather than make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ dist:
 #Clean out some gunk
 	rm -rf $(RELEASE)/__MACOSX
 #Add the latest database
-	${MAKE} -C db clean all
+	"${MAKE}" -C db clean all
 	cp db/stripped.csv $(RELEASE)/callerid.csv
 #Zip it up for distribution.
 	zip -r $(RELEASE).zip $(RELEASE)
@@ -145,7 +145,7 @@ dbg:
 	-awk -Wversion 2>/dev/null || awk --version
 	@echo ________
 	@echo Make version
-	${MAKE} -v
+	"${MAKE}" -v
 	@echo ________
 
 ci: dbg clean 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ dist:
 #Clean out some gunk
 	rm -rf $(RELEASE)/__MACOSX
 #Add the latest database
-	make -C db clean all
+	${MAKE} -C db clean all
 	cp db/stripped.csv $(RELEASE)/callerid.csv
 #Zip it up for distribution.
 	zip -r $(RELEASE).zip $(RELEASE)
@@ -145,7 +145,7 @@ dbg:
 	-awk -Wversion 2>/dev/null || awk --version
 	@echo ________
 	@echo Make version
-	make -v
+	${MAKE} -v
 	@echo ________
 
 ci: dbg clean 

--- a/annotations/d02.032/Makefile
+++ b/annotations/d02.032/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -f flash.img patch.img
 
 flash.img:
-	cd ../../firmware && $(MAKE) unwrapped/$(IMAGE)
+	cd ../../firmware && "$(MAKE)" unwrapped/$(IMAGE)
 	cp ../../firmware/unwrapped/$(IMAGE) flash.img
 open: flash.img
 	radare2 -a arm -m 0x0800C000 -b 16 -i flash.r $<

--- a/annotations/d13.020/Makefile
+++ b/annotations/d13.020/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f *.tmp *.img
 	
 orig.img: 
-	make -C ../../firmware unwrapped/D013.020.img
+	${MAKE} -C ../../firmware unwrapped/D013.020.img
 	cp ../../firmware/unwrapped/D013.020.img orig.img
     
 	

--- a/annotations/d13.020/Makefile
+++ b/annotations/d13.020/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f *.tmp *.img
 	
 orig.img: 
-	${MAKE} -C ../../firmware unwrapped/D013.020.img
+	"${MAKE}" -C ../../firmware unwrapped/D013.020.img
 	cp ../../firmware/unwrapped/D013.020.img orig.img
     
 	

--- a/annotations/s13.020/Makefile
+++ b/annotations/s13.020/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f *.tmp *.img
 	
 orig.img: 
-	${MAKE} -C ../../firmware unwrapped/S013.020.img
+	"${MAKE}" -C ../../firmware unwrapped/S013.020.img
 	cp ../../firmware/unwrapped/S013.020.img orig.img
     
 sortlink:	

--- a/annotations/s13.020/Makefile
+++ b/annotations/s13.020/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f *.tmp *.img
 	
 orig.img: 
-	make -C ../../firmware unwrapped/S013.020.img
+	${MAKE} -C ../../firmware unwrapped/S013.020.img
 	cp ../../firmware/unwrapped/S013.020.img orig.img
     
 sortlink:	

--- a/locales/Makefile
+++ b/locales/Makefile
@@ -4,22 +4,22 @@ clean:
 	rm -f localize *.bin *.img
 
 applet:
-	cd ../applet && ${MAKE}
+	cd ../applet && "${MAKE}"
 hu: localize applet
 	cat strings.txt | ./localize hu ../applet/merged.img D013.020-hu.img
-	${MAKE} D013.020-hu.bin
+	"${MAKE}" D013.020-hu.bin
 
 it: localize applet
 	cat strings.txt | ./localize it ../applet/merged.img D013.020-it.img
-	${MAKE} D013.020-it.bin
+	"${MAKE}" D013.020-it.bin
 
 de: localize applet
 	cat strings.txt | ./localize de ../applet/merged.img D013.020-de.img
-	${MAKE} D013.020-de.bin
+	"${MAKE}" D013.020-de.bin
 
 es: localize applet
 	cat strings.txt | ./localize es ../applet/merged.img D013.020-es.img
-	${MAKE} D013.020-es.bin
+	"${MAKE}" D013.020-es.bin
 
 sr: localize applet
 	cat strings.txt | ./localize sr ../applet/merged.img D013.020-sr.img

--- a/locales/Makefile
+++ b/locales/Makefile
@@ -4,22 +4,22 @@ clean:
 	rm -f localize *.bin *.img
 
 applet:
-	cd ../applet && make
+	cd ../applet && ${MAKE}
 hu: localize applet
 	cat strings.txt | ./localize hu ../applet/merged.img D013.020-hu.img
-	make D013.020-hu.bin
+	${MAKE} D013.020-hu.bin
 
 it: localize applet
 	cat strings.txt | ./localize it ../applet/merged.img D013.020-it.img
-	make D013.020-it.bin
+	${MAKE} D013.020-it.bin
 
 de: localize applet
 	cat strings.txt | ./localize de ../applet/merged.img D013.020-de.img
-	make D013.020-de.bin
+	${MAKE} D013.020-de.bin
 
 es: localize applet
 	cat strings.txt | ./localize es ../applet/merged.img D013.020-es.img
-	make D013.020-es.bin
+	${MAKE} D013.020-es.bin
 
 sr: localize applet
 	cat strings.txt | ./localize sr ../applet/merged.img D013.020-sr.img

--- a/md380org/Makefile
+++ b/md380org/Makefile
@@ -4,7 +4,7 @@
 all: site
 
 themes:
-	make -C themes all
+	${MAKE} -C themes all
 
 server: themes
 	hugo server --buildDrafts

--- a/md380org/Makefile
+++ b/md380org/Makefile
@@ -4,7 +4,7 @@
 all: site
 
 themes:
-	${MAKE} -C themes all
+	"${MAKE}" -C themes all
 
 server: themes
 	hugo server --buildDrafts


### PR DESCRIPTION
Some systems (such as FreeBSD) have a different make and install
GNU make as gmake.  For these systems, we *must* use ${MAKE} instead
of hard-coding make.