### PR TITLE
Read mfg string before using USB extensions

### DIFF
--- a/md380_tool.py
+++ b/md380_tool.py
@@ -79,6 +79,11 @@ class Tool(DFU):
     """Client class for extra features patched into the MD380's firmware.
     None of this will work with the official firmware, of course."""
 
+    def __init__(self, device, alt):
+        super(Tool, self).__init__(device, alt)
+        # We need to read the manufacturer string to hook the added USB functions
+        device.manufacturer
+
     def drawtext(self, str, a, b):
         """Sends a new MD380 command to draw text on the screen.."""
         cmd = 0x80  # Drawtext

--- a/tool2.py
+++ b/tool2.py
@@ -215,6 +215,11 @@ class Tool(DFU):
     """Client class for extra features patched into the MD380's firmware.
     None of this will work with the official firmware, of course."""
     
+    def __init__(self, device, alt):
+        super(Tool, self).__init__(device, alt)
+        # We need to read the manufacturer string to hook the added USB functions
+        device.manufacturer
+
     def drawtext(self,str,a,b):
         """Sends a new MD380 command to draw text on the screen.."""
         cmd=0x80 #Drawtext


### PR DESCRIPTION
This is what triggers hooking the DFU to enable additional commands.
It seems that on Linux at least, this string is read by default, but
at least on FreeBSD, it is not.

If the string is not accessed, the SPI ID is read as garbage and
the additional commands don't work.  Simply accessing it fixes this.