### PR TITLE
Use getattr() to fetch device.manufactuer

### DIFF
--- a/md380_tool.py
+++ b/md380_tool.py
@@ -82,7 +82,8 @@ class Tool(DFU):
     def __init__(self, device, alt):
         super(Tool, self).__init__(device, alt)
         # We need to read the manufacturer string to hook the added USB functions
-        device.manufacturer
+        # Some systems (Raspian Jessie) don't have this property
+        getattr(device, "manufacturer")
 
     def drawtext(self, str, a, b):
         """Sends a new MD380 command to draw text on the screen.."""

--- a/tool2.py
+++ b/tool2.py
@@ -218,7 +218,8 @@ class Tool(DFU):
     def __init__(self, device, alt):
         super(Tool, self).__init__(device, alt)
         # We need to read the manufacturer string to hook the added USB functions
-        device.manufacturer
+        # Some systems (Raspian Jessie) don't have this property
+        getattr(device, "manufacturer")
 
     def drawtext(self,str,a,b):
         """Sends a new MD380 command to draw text on the screen.."""


### PR DESCRIPTION
Some systems such as Raspian Jessie seem to have a PyUSB that doesn't
support this property, and the get_string() method works differently as
well. getattr() will return the third paramter (None) if the property
doesn't exist, and we don't use the value regardless.