### PR TITLE
HRC5000 new FM features

### DIFF
--- a/applet/Makefile
+++ b/applet/Makefile
@@ -54,6 +54,7 @@ SRCS += etsi.o
 SRCS += sms.o
 SRCS += beep.o
 SRCS += irq_handlers.o
+SRCS += system_hrc5000.o
 SRCS += narrator.o
 SRCS += lcd_driver.o
 SRCS += font_8_8.o

--- a/applet/config.h
+++ b/applet/config.h
@@ -24,6 +24,9 @@
 # define CONFIG_MORSE_OUTPUT 1 // Morse output ? 0 or undef'd=no, 1=yes
 # define CONFIG_APP_MENU 1 // Alternative 'application menu' ? 0=no, 1=yes
 #endif
+/* Support keyb layout of Tytera MD446 (details see irq_handler.c)
+   this unit has a reduced keypad with 6 keys */
+# define CONFIG_MD446 0 // MD446 enable 0 or undef'd=no, 1=yes
 
 /* Uncomment this to print AMBE frames for decoding with DSD.  You
    probable want this instead of AMBECORRECTEDPRINT or

--- a/applet/config.h
+++ b/applet/config.h
@@ -26,7 +26,8 @@
 #endif
 /* Support keyb layout of Tytera MD446 (details see irq_handler.c)
    this unit has a reduced keypad with 6 keys */
-# define CONFIG_MD446 0 // MD446 enable 0 or undef'd=no, 1=yes
+/* # define CONFIG_MD446 0 // MD446 enable 0 or undef'd=no, 1=yes
+   now unused */
 
 /* Uncomment this to print AMBE frames for decoding with DSD.  You
    probable want this instead of AMBECORRECTEDPRINT or

--- a/applet/config.h
+++ b/applet/config.h
@@ -24,10 +24,6 @@
 # define CONFIG_MORSE_OUTPUT 1 // Morse output ? 0 or undef'd=no, 1=yes
 # define CONFIG_APP_MENU 1 // Alternative 'application menu' ? 0=no, 1=yes
 #endif
-/* Support keyb layout of Tytera MD446 (details see irq_handler.c)
-   this unit has a reduced keypad with 6 keys */
-/* # define CONFIG_MD446 0 // MD446 enable 0 or undef'd=no, 1=yes
-   now unused */
 
 /* Uncomment this to print AMBE frames for decoding with DSD.  You
    probable want this instead of AMBECORRECTEDPRINT or

--- a/applet/src/addl_config.c
+++ b/applet/src/addl_config.c
@@ -138,7 +138,9 @@ void init_global_addl_config_hook(void)
     LOGB("t=%d: booting\n", (int)IRQ_dwSysTickCounter ); // 362 SysTicks after power-on
    
     cfg_load();
+#if defined(FW_D13_020) || defined(FW_S13_020)
     set_keyb(global_addl_config.keyb_mode);
+#endif
 
 //#ifdef CONFIG_MENU
     md380_create_main_menu_entry();

--- a/applet/src/addl_config.c
+++ b/applet/src/addl_config.c
@@ -85,6 +85,7 @@ void cfg_load()
 //    R(global_addl_config.boot_splash,0); // unused
     R(global_addl_config.netmon,3);
     R(global_addl_config.datef,6);
+    R(global_addl_config.keyb_mode,3);	// 2017-05-25	0-legacy, 1-modern, 2-MD446, 3-develop
 
     // restore dmrid
     if( ( global_addl_config.cp_override & CPO_DMR ) == CPO_DMR ) {
@@ -137,6 +138,7 @@ void init_global_addl_config_hook(void)
     LOGB("t=%d: booting\n", (int)IRQ_dwSysTickCounter ); // 362 SysTicks after power-on
    
     cfg_load();
+    set_keyb(global_addl_config.keyb_mode);
 
 //#ifdef CONFIG_MENU
     md380_create_main_menu_entry();

--- a/applet/src/addl_config.c
+++ b/applet/src/addl_config.c
@@ -15,7 +15,8 @@
 #include "radio_config.h"
 #include "syslog.h"
 #include "usersdb.h"
-#include "irq_handlers.h"  // boot_flags, BOOT_FLAG_LOADED_CONFIG defined here
+#include "irq_handlers.h" 	// boot_flags, BOOT_FLAG_LOADED_CONFIG defined here
+#include "system_hrc5000.h"	// set HRC5000 FM register during startup to config values
 
 addl_config_t global_addl_config;
 
@@ -85,7 +86,15 @@ void cfg_load()
 //    R(global_addl_config.boot_splash,0); // unused
     R(global_addl_config.netmon,3);
     R(global_addl_config.datef,6);
-    R(global_addl_config.keyb_mode,3);	// 2017-05-25	0-legacy, 1-modern, 2-MD446, 3-develop
+    R(global_addl_config.fm_bpf,1);
+    R(global_addl_config.fm_comp,1);
+    R(global_addl_config.fm_preemp,1);
+    R(global_addl_config.fm_bw,1);
+    R(global_addl_config.fm_dev,6);
+    R(global_addl_config.fm_mode,255);		// 2017-06-07	0x00-0xFF FM Opmode register
+    R(global_addl_config.keyb_mode,3);		// 2017-05-25	0-legacy, 1-modern, 2-MD446, 3-develop
+    R(global_addl_config.scroll_mode,2);  	// 2017-06-10   0=off, 1=fast, 2=slow
+    R(global_addl_config.devmode_level,3);	// 2017-06-06	0-off, 1-show FM options, 2-extended USB logging, 3-hide menus
 
     // restore dmrid
     if( ( global_addl_config.cp_override & CPO_DMR ) == CPO_DMR ) {
@@ -139,7 +148,9 @@ void init_global_addl_config_hook(void)
    
     cfg_load();
 #if defined(FW_D13_020) || defined(FW_S13_020)
-    set_keyb(global_addl_config.keyb_mode);
+    set_keyb(global_addl_config.keyb_mode);		// set keyboard to correct mode selected in config menu
+    hrc5000_buffer_flush();				
+    hrc5000_fm_set();					// set HRC5000 FM register during startup to config settings
 #endif
 
 //#ifdef CONFIG_MENU

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -64,5 +64,6 @@ void cfg_fix_radioname();
 void cfg_set_radio_name();
 
 void cfg_save();
+void set_keyb();
 
 #endif

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -64,6 +64,5 @@ void cfg_fix_radioname();
 void cfg_set_radio_name();
 
 void cfg_save();
-void set_keyb();
 
 #endif

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -48,7 +48,7 @@ typedef struct addl_config {
        // The above 16-bit colours use the display's native 'BGR565'-format,
        // as used for the 'alternative' menu and the alternative LCD driver:
        // BLUE component in bits 15..11, GREEN in bits 10..5, RED in bits 4..0 .
-
+    uint8_t mic_gain; // 0=Disabled, 1=2db dgain, 2=6db gain
 } addl_config_t ;
 
 #define CPO_BL1 0x1

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -49,6 +49,7 @@ typedef struct addl_config {
        // as used for the 'alternative' menu and the alternative LCD driver:
        // BLUE component in bits 15..11, GREEN in bits 10..5, RED in bits 4..0 .
     uint8_t mic_gain; // 0=Disabled, 1=2db dgain, 2=6db gain
+    uint8_t keyb_mode; // Keyboad layout/mode 0=legacy, 1=modern, 2=MD446, 3=developer
 } addl_config_t ;
 
 #define CPO_BL1 0x1

--- a/applet/src/addl_config.h
+++ b/applet/src/addl_config.h
@@ -27,29 +27,37 @@ typedef struct addl_config {
     uint8_t rbeep;
     uint32_t dmrid;
     uint8_t boot_demo; 
-    uint8_t _boot_splash; // unused
-    char _rname[32]; // unused.
+    uint8_t _boot_splash; 	// unused
+    char _rname[32]; 		// unused.
     uint8_t cp_override ;
     char bootline1[10];
     char bootline2[10];
     uint8_t backlight_intensities; // lower nibble = backlight intensity during IDLE,  upper nibble = backlight intensity during ACTIVITY
-    uint8_t narrator_mode; // Mode / verbosity for CW output. See narrator.c .
-    uint8_t cw_pitch_10Hz; // 'CW pitch' in TEN HERTZ units, to fit in a BYTE.
-    uint8_t cw_volume;    // output 'volume' (PWM duty cycle) for CW messages. 
+    uint8_t narrator_mode; 	// Mode / verbosity for CW output. See narrator.c .
+    uint8_t cw_pitch_10Hz; 	// 'CW pitch' in TEN HERTZ units, to fit in a BYTE.
+    uint8_t cw_volume;    	// output 'volume' (PWM duty cycle) for CW messages. 
       //  0..100 [%] for fixed volume, or BEEP_VOLUME_AUTO to control via pot:
 #     define BEEP_VOLUME_AUTO 255
     uint8_t cw_speed_WPM;  // CW output speed,  measured in words per minute .
-    uint16_t fg_color;  // foreground (text) colour for own menus, and maybe console screens too
-    uint16_t bg_color;  // normal background colour, also customizeable in app_menu.c ...
-    uint16_t sel_fg_color;  // fg colour to mark the selection- or navigation bar
-    uint16_t sel_bg_color;  // bg colour to mark the selection- or navigation bar
-    uint16_t edit_fg_color; // fg colour of a cell in "edit mode" (or, single char for the CURSOR)
-    uint16_t edit_bg_color; // fg colour of a cell in "edit mode" (or, single char for the CURSOR)
+    uint16_t fg_color;  	// foreground (text) colour for own menus, and maybe console screens too
+    uint16_t bg_color;  	// normal background colour, also customizeable in app_menu.c ...
+    uint16_t sel_fg_color;  	// fg colour to mark the selection- or navigation bar
+    uint16_t sel_bg_color;  	// bg colour to mark the selection- or navigation bar
+    uint16_t edit_fg_color; 	// fg colour of a cell in "edit mode" (or, single char for the CURSOR)
+    uint16_t edit_bg_color; 	// fg colour of a cell in "edit mode" (or, single char for the CURSOR)
        // The above 16-bit colours use the display's native 'BGR565'-format,
        // as used for the 'alternative' menu and the alternative LCD driver:
        // BLUE component in bits 15..11, GREEN in bits 10..5, RED in bits 4..0 .
-    uint8_t mic_gain; // 0=Disabled, 1=2db dgain, 2=6db gain
-    uint8_t keyb_mode; // Keyboad layout/mode 0=legacy, 1=modern, 2=MD446, 3=developer
+    uint8_t mic_gain;		// 0=Disabled, 1=2db dgain, 2=6db gain
+    uint8_t fm_bpf;		// 0=off, 1=on
+    uint8_t fm_comp;		// 0=off, 1=on
+    uint8_t fm_preemp;		// 0=off, 1=on
+    uint8_t fm_bw;		// 0=12.5kHz, 1=25kHz
+    uint8_t fm_dev;		// 0=default 1-5=user selectable
+    uint8_t fm_mode;		// 0x00-0xFF current register value of FM mode
+    uint8_t keyb_mode;  	// Keyboad layout/mode 0=legacy, 1=modern, 2=MD446, 3=developer
+    uint8_t scroll_mode;  	// Keyboad scroll 0=off, 1=fast, 2=slow
+    uint8_t devmode_level;	// Developer mode 0-off, 1-show FM options, 2-extended USB, 3-hide menu #1,#2,#5
 } addl_config_t ;
 
 #define CPO_BL1 0x1
@@ -65,5 +73,7 @@ void cfg_set_radio_name();
 
 void cfg_save();
 void set_keyb();
+void hrc5000_buffer_flush();				
+void hrc5000_fm_set();
 
 #endif

--- a/applet/src/console.c
+++ b/applet/src/console.c
@@ -171,7 +171,7 @@ static void con_draw1()
     
     // erase bottom stripe.
     gfx_set_fg_color(bgcolor); 
-    gfx_blockfill(0, MAX_Y-10, MAX_X, MAX_Y); 
+    gfx_blockfill(0, MAX_Y-9, MAX_X, MAX_Y); 		// fix by MAX_Y-9 instead of -10 overwrite of lowest pixel/line in bottom area of netmon screens
     // erase left 1 pixels
     gfx_blockfill(0, 0, LEFT_POS-1, MAX_Y); 
     

--- a/applet/src/gfx.c
+++ b/applet/src/gfx.c
@@ -202,7 +202,7 @@ void print_date_hook(void)
 
 void print_time_hook(const char log)
 {
-    if( is_netmon_visible() ) {
+    if( is_netmon_visible() && nm_screen < 4 ) {							// 2017-05-21 fix missing timestamp output for netmon4,5,6
         return;
     }
     wchar_t wide_time[9];

--- a/applet/src/irq_handlers.c
+++ b/applet/src/irq_handlers.c
@@ -1057,7 +1057,7 @@ char KeyRowColToASCII(uint16_t kb_row_col)
   //   | 0x0024 | 0x0014 | 0x000C |     |  
   //   |________|________|________|   --
   //  
-#if( CONFIG_MD446 )
+ if ( global_addl_config.keyb_mode == 2) {		// support for MD-446 keyb layout
   switch( kb_row_col ) // sorted by switch-value for shortest code..
    { case 0x000A : return 'B'; // 'back' aka 'red button'
      case 0x0012 : return 'U'; // cursor up
@@ -1072,7 +1072,7 @@ char KeyRowColToASCII(uint16_t kb_row_col)
      case 0x002A : return 'X'; // eXit all menus and sub-menus
      default     : return  0;
    }
-#else
+ } else {
   switch( kb_row_col ) // sorted by switch-value for shortest code..
    { case 0x000A : return 'M'; // Green 'Menu' key (which usually opens TYTERA's menu)
      case 0x000C : return '1';
@@ -1095,7 +1095,7 @@ char KeyRowColToASCII(uint16_t kb_row_col)
      case 0x040A : return 'X'; // eXit all menus and sub-menus
      default     : return  0;
    }
-#endif
+ }
 
 } // end KeyRowColToASCII()
 #endif // CAN_POLL_KEYS ?
@@ -1104,21 +1104,21 @@ char KeyRowColToASCII(uint16_t kb_row_col)
   //---------------------------------------------------------------------------
 int KeyRowColToVal(uint16_t kb_row_col)
 { 
-#if( CONFIG_MD446 )
+ if ( global_addl_config.keyb_mode == 2) {		// support for MD-446 keyb layout
 	switch (kb_row_col) // sorted by switch-value for shortest code..
 	{
-	case 0x000A: return 13; // 'back' aka 'red button'
-	case 0x000C: return 4; // P2
-	case 0x0012: return 11; // cursor up
-	case 0x0014: return 14;  // cursor down
+	case 0x000A: return 13;	// 'back' aka 'red button'
+	case 0x000C: return 4;	// P2
+	case 0x0012: return 11;	// cursor up
+	case 0x0014: return 14;	// cursor down
 	case 0x0022: return 30; // Green 'Menu' key
-	case 0x0024: return 7; // P1
+	case 0x0024: return 7;	// P1
 		// kb_row_col_pressed also supports a few COMBINATIONS:
 		//   MENU+BACK (simultaneously pressed) : 0x040A
 	case 0x002A: return 55; // eXit all menus and sub-menus
 	default: return 0;
 	}
-#else
+ } else {
 	switch (kb_row_col) // sorted by switch-value for shortest code..
 	{
 	case 0x000A: return 30; // Green 'Menu' key (which usually opens TYTERA's menu)
@@ -1142,7 +1142,7 @@ int KeyRowColToVal(uint16_t kb_row_col)
 	case 0x040A: return 55; // eXit all menus and sub-menus
 	default: return 0;
 	}
-#endif
+ }
 } // end KeyRowColToASCII()
 #endif // CAN_POLL_KEYS ?
 
@@ -1342,8 +1342,6 @@ static void PollKeysForScroll(void)
 
 } // end PollKeysForScroll()
 
-
-
 #endif // CONFIG_APP_MENU ?
 
 
@@ -1539,31 +1537,29 @@ void SysTick_Handler(void)
 
   if( oldSysTickCounter > 3000 )
    { // Some seconds after power-on, begin to poll analog inputs...
-     if( (oldSysTickCounter & 0x0F) == 0 ) // .. on every 16-th SysTiein spiegelverkehrte Ausschnitt der 3 Keysck
-      { PollAnalogInputs(); // -> battery_voltage_mV, volume_pot_pos 
-      }
-#   if( CAN_POLL_KEYS && CONFIG_APP_MENU ) // Poll keys ?
-     if( (oldSysTickCounter & 0x0F) == 1 ) // .. on every 16-th SysTick
-      { // (but not in the same interrupt as PollAnalogInputs)
-        PollKeys(); // non-intrusive polling of keys, with autorepeat
-      }
-	 if ((oldSysTickCounter & 0x6F) == 1) // .. on every 16-th SysTick
-	 { // (but not in the same interrupt as PollAnalogInputs)
-
-		 PollKeysForScroll(); // non-intrusive polling of keys for the 
-							   // 'red menu' (menu activated by pressing the red 'BACK'-button,
-							   // when that button isn't used to control Tytera's own menu).
-	 }
-
-#   endif // CONFIG_APP_MENU ?
+	if( (oldSysTickCounter & 0x0F) == 0 ) // .. on every 16-th SysTick
+	{ PollAnalogInputs(); // -> battery_voltage_mV, volume_pot_pos 
+	}
+#if( CAN_POLL_KEYS && CONFIG_APP_MENU ) // Poll keys ?
+	if( (oldSysTickCounter & 0x0F) == 1 ) // .. on every 16-th SysTick
+	{ // (but not in the same interrupt as PollAnalogInputs)
+	PollKeys(); // non-intrusive polling of keys, with autorepeat
+	}
+	if ((oldSysTickCounter & 0x6F) == 1) // .. on every 111-th SysTick
+	{ // (but not in the same interrupt as PollAnalogInputs)
+	PollKeysForScroll(); 	// non-intrusive polling of keys for the 
+				// 'red menu' (menu activated by pressing the red 'BACK'-button,
+			   	// when that button isn't used to control Tytera's own menu).
+	}
+#endif // CONFIG_APP_MENU ?
    } // end if( oldSysTickCounter > 6000 )
 
-#   if( CONFIG_MORSE_OUTPUT ) // Morse output (optional, since 2017-02-19) ?
+#if( CONFIG_MORSE_OUTPUT ) // Morse output (optional, since 2017-02-19) ?
      if( morse_generator.u8State != MORSE_GEN_PASSIVE )
       { // Only spend time on this when active !
         MorseGen_OnTimerTick( &morse_generator );
       }
-#   endif  // CONFIG_MORSE_OUTPUT ?
+#endif  // CONFIG_MORSE_OUTPUT ?
    } // end if < all necessary bits in boot_flags set > ?
  
 

--- a/applet/src/irq_handlers.c
+++ b/applet/src/irq_handlers.c
@@ -1046,6 +1046,33 @@ char KeyRowColToASCII(uint16_t kb_row_col)
   //   | 0x0042 | 0x0082 | 0x0102 | 0x0202 |     |
   //   |________|________|________|________|   --
   //  
+  //   Tytera MD-446 Layout - 20170522 DL2MF
+  //    ___________________________    
+  //   | 'M'ENU | cursor | 'B'ACK |   __
+  //   |(green) |  up, U | (red)  |     \  mirrored to left 3 cols of
+  //   | 0x0022 | 0x0012 | 0x000A |   __/  default MD380/MD390 layout
+  //   |--------+--------+--------|   __  
+  //   |  'P1'  | cursor |  'P2'  |     |
+  //   |    3   |  dn, D |    1   |     |  only P1 up/DN P2
+  //   | 0x0024 | 0x0014 | 0x000C |     |  
+  //   |________|________|________|   --
+  //  
+#if( CONFIG_MD446 )
+  switch( kb_row_col ) // sorted by switch-value for shortest code..
+   { case 0x000A : return 'B'; // 'back' aka 'red button'
+     case 0x0012 : return 'U'; // cursor up
+     case 0x0022 : return 'M'; // Green 'Menu' key
+
+     case 0x000C : return '4'; // P2
+     case 0x0014 : return 'D'; // cursor dn 
+     case 0x0024 : return '7'; // P1
+
+     // kb_row_col_pressed also supports a few COMBINATIONS:
+     //   MENU+BACK (simultaneously pressed) : 0x040A
+     case 0x002A : return 'X'; // eXit all menus and sub-menus
+     default     : return  0;
+   }
+#else
   switch( kb_row_col ) // sorted by switch-value for shortest code..
    { case 0x000A : return 'M'; // Green 'Menu' key (which usually opens TYTERA's menu)
      case 0x000C : return '1';
@@ -1066,13 +1093,64 @@ char KeyRowColToASCII(uint16_t kb_row_col)
      // kb_row_col_pressed also supports a few COMBINATIONS:
      //   MENU+BACK (simultaneously pressed) : 0x040A
      case 0x040A : return 'X'; // eXit all menus and sub-menus
-     default     : return 0;
+     default     : return  0;
    }
+#endif
+
 } // end KeyRowColToASCII()
 #endif // CAN_POLL_KEYS ?
 
+#if( CAN_POLL_KEYS ) // <- def'd as 0 or 1 in keyb.h, depends on firmware variant, subject to change
+  //---------------------------------------------------------------------------
+int KeyRowColToVal(uint16_t kb_row_col)
+{ 
+#if( CONFIG_MD446 )
+	switch (kb_row_col) // sorted by switch-value for shortest code..
+	{
+	case 0x000A: return 13; // 'back' aka 'red button'
+	case 0x000C: return 4; // P2
+	case 0x0012: return 11; // cursor up
+	case 0x0014: return 14;  // cursor down
+	case 0x0022: return 30; // Green 'Menu' key
+	case 0x0024: return 7; // P1
+		// kb_row_col_pressed also supports a few COMBINATIONS:
+		//   MENU+BACK (simultaneously pressed) : 0x040A
+	case 0x002A: return 55; // eXit all menus and sub-menus
+	default: return 0;
+	}
+#else
+	switch (kb_row_col) // sorted by switch-value for shortest code..
+	{
+	case 0x000A: return 30; // Green 'Menu' key (which usually opens TYTERA's menu)
+	case 0x000C: return 1;
+	case 0x0012: return 11; // cursor up
+	case 0x0014: return 2;
+	case 0x0022: return 12; // cursor down
+	case 0x0024: return 3;
+	case 0x0042: return 7;
+	case 0x0044: return 4;
+	case 0x0082: return 8;
+	case 0x0084: return 5;
+	case 0x0102: return 9;
+	case 0x0104: return 6;
+	case 0x0202: return 15;
+	case 0x0204: return 0;
+	case 0x0402: return 13; // 'back' aka 'red button'
+	case 0x0404: return 14;
+		// kb_row_col_pressed also supports a few COMBINATIONS:
+		//   MENU+BACK (simultaneously pressed) : 0x040A
+	case 0x040A: return 55; // eXit all menus and sub-menus
+	default: return 0;
+	}
+#endif
+} // end KeyRowColToASCII()
+#endif // CAN_POLL_KEYS ?
 
 #if( CAN_POLL_KEYS && CONFIG_APP_MENU ) // optional feature ...
+
+static uint32_t green_menu_countdown = 0;
+static uint32_t autorepeat_countdown = 0;
+
 //---------------------------------------------------------------------------
 static void PollKeys(void)
   // Non-intrusive polling of keys for the 'app menu' (activated 
@@ -1177,6 +1255,95 @@ static void PollKeys(void)
       }
    } // key_init_countdown ?
 } // end PollKeys()
+
+static void PollKeysForScroll(void)
+// Non-intrusive polling of keys for the 'red menu' (activated 
+//  by pressing the red 'BACK'-button),
+// when that button isn't used to control Tytera's own 'geen' menu.
+// Called approximately once every 24 milliseconds from SysTick_Handler(), 
+// so don't call anything else from here (especially nothing in
+// the original firmware, unless you know exactly what you're doing).
+// Only peek at a few locations in RAM, and carefully set some others.
+{
+
+	static uint16_t prev_key;
+	uint16_t key = kb_row_col_pressed;
+	// 'kb_keycode' is useless here because it doesn't return to zero 
+	// when releasing a key.
+	// So use 'kb_row_col_pressed' (16 bit) instead . Seems to be the
+	// lowest level of polling the keyboard matrix without rolling our own.
+	// 
+	// Our own ("red") menu must not interfere with Tyter's "green" menu,
+	// where the red "BACK"-button switches back from any submenu to the
+	// parent, and from the main menu to the main screen:
+
+	if (KeyRowColToVal(key) != 11 && KeyRowColToVal(key) != 12) {
+		autorepeat_countdown = 500/*ms*/ / 12;
+	}
+
+	if (gui_opmode2 == OPM2_MENU)
+	{ // keyboard focus currently on Tytera's 'green' menu 
+	  // -> ignore kb_row_col_pressed until the key was released
+		green_menu_countdown = 200/*ms*/ / 24;
+		if (KeyRowColToVal(key) == 11 || KeyRowColToVal(key) == 12) {
+			kb_handle(KeyRowColToVal(key));
+			autorepeat_countdown = 500/*ms*/ / 12;
+		}
+
+	}
+	else // keyboard focus not on Tytera's ('green') menu...
+	{   // so is it "our" key now ?  Not necessarily !
+		// Tytera's menu already quits when PRESSING the red button,
+		// so just because the red button is PRESSED doesn't mean 
+		// the operator wants to open our 'red menu'.  Thus:
+		if (green_menu_countdown > 0)
+		{
+			if (key == 0)
+			{
+				autorepeat_countdown = 500/*ms*/ / 12;
+				--green_menu_countdown;
+			}
+			else // guess the RED BUTTON is still pressed after leaving the GREEN-button-menu
+			{
+				green_menu_countdown = 200/*ms*/ / 24; // ignore keypress for another 200 ms
+			}
+		}
+		else // "green menu" countdown expired, guess the alternative menu may process this key..
+		{
+			if (prev_key == 0 && key != 0)
+			{
+				kb_handle(KeyRowColToVal(key));
+				//Menu_OnKey(KeyRowColToASCII(key));
+
+				// no fancy FIFO but a simple 1-level buffer.
+				// Consumed in another task or thread, see app_menu.c 
+				autorepeat_countdown = 500/*ms*/ / 12; // <- autorepeat DELAY
+			}
+			else // no CHANGE in the keyboard matrix, but maybe...
+				if (key == 0x0012 || key == 0x0022) // cursor key still pressed ?
+				{
+					if (autorepeat_countdown > 0)
+					{
+						--autorepeat_countdown;
+					}
+					else // send the same key again, prevents rubbing the paint off..  
+					{
+						autorepeat_countdown = 80/*ms*/ / 24; // 1 / "autorepeat RATE"
+
+						//Menu_OnKey(KeyRowColToASCII(key));
+						kb_handle(KeyRowColToVal(key));
+
+
+					}
+				}
+		}
+	}
+	prev_key = key;
+
+} // end PollKeysForScroll()
+
+
+
 #endif // CONFIG_APP_MENU ?
 
 
@@ -1370,8 +1537,9 @@ void SysTick_Handler(void)
       }   // end else < backlight not completely dark >
 #   endif  // CONFIG_DIMMED_LIGHT ?
 
-     // Poll analog inputs
-     if( (oldSysTickCounter & 0x0F) == 0 ) // .. on every 16-th SysTick
+  if( oldSysTickCounter > 3000 )
+   { // Some seconds after power-on, begin to poll analog inputs...
+     if( (oldSysTickCounter & 0x0F) == 0 ) // .. on every 16-th SysTiein spiegelverkehrte Ausschnitt der 3 Keysck
       { PollAnalogInputs(); // -> battery_voltage_mV, volume_pot_pos 
       }
 #   if( CAN_POLL_KEYS && CONFIG_APP_MENU ) // Poll keys ?
@@ -1379,7 +1547,16 @@ void SysTick_Handler(void)
       { // (but not in the same interrupt as PollAnalogInputs)
         PollKeys(); // non-intrusive polling of keys, with autorepeat
       }
+	 if ((oldSysTickCounter & 0x6F) == 1) // .. on every 16-th SysTick
+	 { // (but not in the same interrupt as PollAnalogInputs)
+
+		 PollKeysForScroll(); // non-intrusive polling of keys for the 
+							   // 'red menu' (menu activated by pressing the red 'BACK'-button,
+							   // when that button isn't used to control Tytera's own menu).
+	 }
+
 #   endif // CONFIG_APP_MENU ?
+   } // end if( oldSysTickCounter > 6000 )
 
 #   if( CONFIG_MORSE_OUTPUT ) // Morse output (optional, since 2017-02-19) ?
      if( morse_generator.u8State != MORSE_GEN_PASSIVE )

--- a/applet/src/irq_handlers.h
+++ b/applet/src/irq_handlers.h
@@ -78,6 +78,10 @@ extern uint8_t boot_flags; // bitwise combination of the following flags:
 
 extern volatile uint32_t IRQ_dwSysTickCounter; // Incremented each 1.5 ms
 
+
+extern uint8_t GFX_backlight_on; // 0="off" (low intensity), 1="on" (high intensity) 
+//   (note: GFX_backlight_on is useless, as long as no-one calls gfx.c : 
+
 extern uint8_t kb_backlight; // flag to disable the backlight via sidekey (in keyb.c)
 
 extern uint8_t red_led_timer;   // 'countdown' timer, in 1.5 ms steps, to turn

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -341,6 +341,7 @@ extern void kb_handler();
 
 static int nextKey = -1;
 
+#if defined(FW_D13_020) || defined(FW_S13_020)
 void kb_handle(int key) {
 	int kp = kb_keypressed;
 	int kc = key;
@@ -367,6 +368,7 @@ void kb_handle(int key) {
 	}
 #endif
 }
+#endif
 
 void kb_handler_hook()
 {

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -134,7 +134,8 @@ extern void gui_control( int r0 );
 
 void handle_hotkey( int keycode )
 {
-    PRINT("handle hotkey: %d\n", keycode );
+    if (global_addl_config.devmode_level != 0) 	
+	PRINT("handle hotkey: %d\n", keycode );
     
     reset_backlight();
   
@@ -263,13 +264,16 @@ void evaluate_sidekey( int button_function) // This is where new functions for s
 
 void trace_keyb(int sw)
 {
-    static uint8_t old_kp = -1 ;
-    uint8_t kp = kb_keypressed ;
+	if (global_addl_config.devmode_level > 2)
+	{
+		static uint8_t old_kp = -1 ;
+		uint8_t kp = kb_keypressed ;
     
-    if( old_kp != kp ) {
-        PRINT("kp: %d %02x -> %02x (%04x) (%d)\n", sw, old_kp, kp, kb_row_col_pressed, kb_keycode );
-        old_kp = kp ;
-    }
+		if( old_kp != kp ) {
+		PRINT("kp: %d %02x -> %02x (%04x) (%d)\n", sw, old_kp, kp, kb_row_col_pressed, kb_keycode );
+		old_kp = kp ;
+    		}
+	}
 }
 
 void set_keyb(int keyb_mode)

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -426,11 +426,11 @@ void kb_handler_hook()
 		kc = 11;				// Cursor up - NEVER change this!!
         	break ;
         case 3 :
-		kc = 15;					// define your preferred P1 function: 0=Netmon6 2=Netmon5 4=Netmon4 8=Netmon1 9=Netmon2 15=Netmon3
+		kc = 4;					// define your preferred P1 function: 0=Netmon6 2=Netmon5 4=Netmon4 8=Netmon1 9=Netmon2 15=Netmon3
         	break ;	
         case 2 :
 		kb_keycode = 12;			// Cursor down - is also used for quick menu access!
-		kc = 4;					// Cursor down - NEVER change this!!
+		kc = 12;				// Cursor down - NEVER change this!!
         	break ;
         case 1 :
 		kc = 7;					// exit from Netmon screens

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -494,9 +494,10 @@ inline int is_intercepted_keycode2(uint8_t kc)
 
 extern void kb_handler();
 
-static int nextKey = -1;
 
 #if defined(FW_D13_020) || defined(FW_S13_020)
+static int nextKey = -1;
+
 void kb_handle(int key) {
 	int kp = kb_keypressed;
 	int kc = key;

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -499,18 +499,13 @@ extern void kb_handler();
 static int nextKey = -1;
 
 void kb_handle(int key) {
-	int kp = kb_keypressed;
+
 	int kc = key;
-
-
 
 	if (is_intercept_allowed()) {
 		if (is_intercepted_keycode2(kc)) {
-			//if ((kp & 2) == 2) {
-				//kb_keypressed = 8;
 				handle_hotkey(kc);
 				return;
-			//}
 		}
 	}
 
@@ -519,19 +514,6 @@ void kb_handle(int key) {
 		kb_keycode = key;
 		kb_keypressed = 2;
 	}
-
-/*
-if ( global_addl_config.keyb_mode == 2) {		// support for MD-446 keyb layout
-		if (key == 11 || key == 2) {
-			kb_keycode = key;
-			kb_keypressed = 2;
-		}
-	} else {
-		if (key == 11 || key == 12) {
-			kb_keycode = key;
-			kb_keypressed = 2;
-		}
-	}*/
 }
 #endif
 

--- a/applet/src/keyb.h
+++ b/applet/src/keyb.h
@@ -51,6 +51,7 @@ extern uint8_t kb_bot_side_key_press_time;
 extern uint8_t kb_side_key_max_time;
 
 void evaluate_sidekey(int);
+void kb_handle(int);
 #else
 # define CAN_POLL_KEYS 0  /* 0 : cannot poll keys for this firmware yet */
 #endif

--- a/applet/src/keyb.h
+++ b/applet/src/keyb.h
@@ -27,8 +27,8 @@ typedef enum {
 	KC_UP = 11,
 	KC_DOWN = 12,
 	KC_BACK = 13,
-	KC_ASTERISK = 14,
-	KC_OCTOTHORPE = 15
+	KC_STAR = 14,
+	KC_HASH = 15
 } keycode_t;
 
 void f_4101();
@@ -49,9 +49,28 @@ extern uint16_t backlight_timer;   // seems to be a COUNTDOWN, decremented every
 extern uint8_t kb_top_side_key_press_time;
 extern uint8_t kb_bot_side_key_press_time;
 extern uint8_t kb_side_key_max_time;
+// define keycodes for variable assignment
+uint8_t kc_netmon1;
+uint8_t kc_netmon2;
+uint8_t kc_netmon3;
+uint8_t kc_netmon4;
+uint8_t kc_netmon5;
+uint8_t kc_netmon6;
+uint8_t kc_sms_test;
+uint8_t kc_talkgroup;
+uint8_t kc_copy_contact;
+uint8_t kc_netmon_clear;
+uint8_t kc_netmon_off;
+uint8_t kc_syslog_dump;
+uint8_t kc_cursor_up;
+uint8_t kc_cursor_down;
+uint8_t kc_greenmenu;
+uint8_t kc_redback;
+uint8_t kc_lastmode;
 
 void evaluate_sidekey(int);
 void kb_handle(int);
+void set_keyb(int);
 #else
 # define CAN_POLL_KEYS 0  /* 0 : cannot poll keys for this firmware yet */
 #endif

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -738,7 +738,9 @@ void create_menu_entry_keyb_mode_legacy_screen(void)
     mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_legacy);
     global_addl_config.keyb_mode = 0;
     cfg_save();
+#if defined(FW_D13_020) || defined(FW_S13_020)
     set_keyb(global_addl_config.keyb_mode);
+#endif
 }
 
 void create_menu_entry_keyb_mode_modern_screen(void)
@@ -746,7 +748,9 @@ void create_menu_entry_keyb_mode_modern_screen(void)
     mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_modern);
     global_addl_config.keyb_mode = 1;
     cfg_save();
+#if defined(FW_D13_020) || defined(FW_S13_020)
     set_keyb(global_addl_config.keyb_mode);
+#endif
 }
 
 void create_menu_entry_keyb_mode_MD446_screen(void)
@@ -754,7 +758,9 @@ void create_menu_entry_keyb_mode_MD446_screen(void)
     mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_MD446);
     global_addl_config.keyb_mode = 2;
     cfg_save();
+#if defined(FW_D13_020) || defined(FW_S13_020)
     set_keyb(global_addl_config.keyb_mode);
+#endif
 }
 
 void create_menu_entry_keyb_mode_dev_screen(void)
@@ -762,7 +768,9 @@ void create_menu_entry_keyb_mode_dev_screen(void)
     mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_dev);
     global_addl_config.keyb_mode = 3;
     cfg_save();
+#if defined(FW_D13_020) || defined(FW_S13_020)
     set_keyb(global_addl_config.keyb_mode);
+#endif
 }
 
 //==========================================================================================================//

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -70,6 +70,10 @@ const static wchar_t wt_bl5[]               = L"5 sec";
 const static wchar_t wt_bl30[]              = L"30 sec";
 const static wchar_t wt_bl60[]              = L"60 sec";
 
+const static wchar_t wt_micgain[]               = L"Mic gain";
+const static wchar_t wt_micgain_3db[]           = L"3db Gain";
+const static wchar_t wt_micgain_6db[]           = L"6db Gain";
+
 
 const static wchar_t wt_backlight_menu[]   = L"Backlight";
 
@@ -462,6 +466,40 @@ void create_menu_entry_demo_screen(void)
     mn_submenu_finalize();
 }
 
+
+void create_menu_entry_micgain_6db_screen(void)
+{
+    mn_create_single_timed_ack(wt_micgain, wt_micgain_6db);
+    global_addl_config.mic_gain = 2;
+    cfg_save();
+}
+
+void create_menu_entry_micgain_3db_screen(void)
+{
+    mn_create_single_timed_ack(wt_micgain, wt_micgain_3db);
+    global_addl_config.mic_gain = 1;
+    cfg_save();
+}
+
+void create_menu_entry_micgain_disable_screen(void)
+{
+    mn_create_single_timed_ack(wt_micgain, wt_disable);
+    global_addl_config.mic_gain = 0;
+    cfg_save();
+}
+
+void create_menu_entry_micgain_screen(void)
+{
+	mn_submenu_init(wt_micgain);
+
+	md380_menu_entry_selected = global_addl_config.mic_gain;
+	mn_submenu_add(wt_demoscr_disable, create_menu_entry_micgain_disable_screen);
+	mn_submenu_add(wt_micgain_3db, create_menu_entry_micgain_3db_screen);
+	mn_submenu_add(wt_micgain_6db, create_menu_entry_micgain_6db_screen);
+
+	mn_submenu_finalize();
+}
+
 void mn_cp_override_off(void)
 {
     mn_create_single_timed_ack(wt_cp_override, wt_splash_manual);
@@ -782,7 +820,7 @@ void create_menu_entry_datef_screen(void)
 
 
 //==========================================================================================================//
-// main(?) menu: showcall - select callsign display method
+// main menu: showcall - select callsign display method
 //==========================================================================================================//
 
 void create_menu_entry_showcall_screen(void)
@@ -1726,25 +1764,54 @@ void create_menu_entry_addl_functions_screen(void)
     PRINTRET();
     PRINT("create_menu_entry_addl_functions_screen\n");
 
+//==================================================================//
+//  MD380Tools - Menu order (often used functions top and bottom!)
+//  --------------------------------------------------------------
+//   1 M. RogerBeep
+//   2 Boot Options
+//   3 Date Format
+//   4 Show Calls 
+//   ---------------
+//   5 USB logging 
+//   6 Promiscous
+//   7 Edit DMR-ID
+//   8 Morse output
+//   ---------------
+//   9 Config Reset
+//  10 Experimental
+//  11 Mic bargraph
+//  12 Mic gain
+//   ---------------
+//  13 Side Buttons 
+//  14 Backlight
+//  15 Set Talkgroup
+//  16 CoPl Override
+//  17 Dev Only
+//==================================================================//
+
+// page 1
     mn_submenu_add_98(wt_rbeep, create_menu_entry_rbeep_screen);
     mn_submenu_add(wt_bootopts, create_menu_entry_bootopts_screen);
     mn_submenu_add_98(wt_datef, create_menu_entry_datef_screen);
     mn_submenu_add_98(wt_showcall, create_menu_entry_showcall_screen);
+// page 2
     mn_submenu_add_98(wt_debug, create_menu_entry_debug_screen);
     mn_submenu_add_98(wt_promtg, create_menu_entry_promtg_screen);
     mn_submenu_add_8a(wt_edit, create_menu_entry_edit_screen, 0); // disable this menu entry - no function jet
     mn_submenu_add_8a(wt_edit_dmr_id, create_menu_entry_edit_dmr_id_screen, 1);
-    mn_submenu_add_8a(wt_set_tg_id, create_menu_entry_set_tg_screen, 1); // Brad's PR#708 already in use here (DL4YHF, since 2017-03)
-    mn_submenu_add_98(wt_micbargraph, create_menu_entry_micbargraph_screen);
-    mn_submenu_add_8a(wt_experimental, create_menu_entry_experimental_screen, 1);
-    mn_submenu_add(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
-    
-    mn_submenu_add_98(wt_config_reset, mn_config_reset);
 
-    mn_submenu_add(wt_backlight_menu, create_menu_entry_backlight_screen);
 #  if( CONFIG_MORSE_OUTPUT )
     mn_submenu_add(wt_morse_menu, create_menu_entry_morse_screen);
 #  endif   
+// page 3
+    mn_submenu_add_98(wt_config_reset, mn_config_reset);
+    mn_submenu_add_8a(wt_experimental, create_menu_entry_experimental_screen, 1);
+    mn_submenu_add_98(wt_micbargraph, create_menu_entry_micbargraph_screen);
+    mn_submenu_add_98(wt_micgain, create_menu_entry_micgain_screen);
+// page 4
+    mn_submenu_add(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
+    mn_submenu_add(wt_backlight_menu, create_menu_entry_backlight_screen);
+    mn_submenu_add_8a(wt_set_tg_id, create_menu_entry_set_tg_screen, 1);
     mn_submenu_add_98(wt_cp_override, mn_cp_override);    
     mn_submenu_add_98(wt_netmon, create_menu_entry_netmon_screen);
     

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -42,11 +42,18 @@ const static wchar_t wt_demoscr_enable[]    = L"Enable";
 const static wchar_t wt_demoscr_disable[]   = L"Disable";
 const static wchar_t wt_splash[]            = L"Splash Mode";
 
-const static wchar_t wt_showcall[]          = L"Show Calls";      // was UsersCSV / enable / disable now added Talker Alias
-const static wchar_t wt_fromcps[]            = L"CPS only";
+const static wchar_t wt_showcall[]          = L"Show Calls";    // was UsersCSV / enable / disable now added Talker Alias
+const static wchar_t wt_fromcps[]           = L"CPS only";
 const static wchar_t wt_usercsv[]           = L"User DB";
 const static wchar_t wt_talkalias[]         = L"Talk Alias";
 const static wchar_t wt_ta_user[]           = L"TA & UserDB";
+
+const static wchar_t wt_keyb_menu[]         = L"Keyb setting";	// main menu - setup side buttons and keyb layout mode
+const static wchar_t wt_keyb_mode[]         = L"Keyb Mode";     // keyb setup - select for different layout and radio models
+const static wchar_t wt_keyb_legacy[]       = L"Legacy";	// Tradiotionally layout of first MD380Tools firmware 
+const static wchar_t wt_keyb_modern[]       = L"Modern";	// Modern keyb layout, reordered functions, special keys right column
+const static wchar_t wt_keyb_MD446[]        = L"MD-446";	// Tytera MD-446 special 6-key layout, no numeric keypad
+const static wchar_t wt_keyb_dev[]          = L"Develop";	// Developer mode
 
 const static wchar_t wt_datef_original[]    = L"YYYY/MM/DD";
 const static wchar_t wt_datef_germany[]     = L"DD.MM.YYYY";
@@ -70,12 +77,12 @@ const static wchar_t wt_bl5[]               = L"5 sec";
 const static wchar_t wt_bl30[]              = L"30 sec";
 const static wchar_t wt_bl60[]              = L"60 sec";
 
-const static wchar_t wt_micgain[]               = L"Mic gain";
-const static wchar_t wt_micgain_3db[]           = L"3db Gain";
-const static wchar_t wt_micgain_6db[]           = L"6db Gain";
+const static wchar_t wt_micgain[]           = L"Mic gain";
+const static wchar_t wt_micgain_3db[]       = L"3db Gain";
+const static wchar_t wt_micgain_6db[]       = L"6db Gain";
 
 
-const static wchar_t wt_backlight_menu[]   = L"Backlight";
+const static wchar_t wt_backlight_menu[]    = L"Backlight";
 
 #ifndef  CONFIG_DIMMED_LIGHT   // Dimmed backlight ?
 # define CONFIG_DIMMED_LIGHT 0 // only if defined > 0 in config.h
@@ -721,6 +728,45 @@ void create_menu_entry_showcall_ta_user_screen(void)
 
 //==========================================================================================================//
 
+
+//==========================================================================================================//
+// submenu: Keyb setup - select keyboard layout
+//==========================================================================================================//
+
+void create_menu_entry_keyb_mode_legacy_screen(void)
+{
+    mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_legacy);
+    global_addl_config.keyb_mode = 0;
+    cfg_save();
+    set_keyb(global_addl_config.keyb_mode);
+}
+
+void create_menu_entry_keyb_mode_modern_screen(void)
+{
+    mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_modern);
+    global_addl_config.keyb_mode = 1;
+    cfg_save();
+    set_keyb(global_addl_config.keyb_mode);
+}
+
+void create_menu_entry_keyb_mode_MD446_screen(void)
+{
+    mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_MD446);
+    global_addl_config.keyb_mode = 2;
+    cfg_save();
+    set_keyb(global_addl_config.keyb_mode);
+}
+
+void create_menu_entry_keyb_mode_dev_screen(void)
+{
+    mn_create_single_timed_ack(wt_keyb_mode,wt_keyb_dev);
+    global_addl_config.keyb_mode = 3;
+    cfg_save();
+    set_keyb(global_addl_config.keyb_mode);
+}
+
+//==========================================================================================================//
+
 void create_menu_entry_experimental_enable_screen(void)
 {
     mn_create_single_timed_ack(wt_experimental,wt_enable);
@@ -820,7 +866,7 @@ void create_menu_entry_datef_screen(void)
 
 
 //==========================================================================================================//
-// main menu: showcall - select callsign display method
+// main menu: Show calls - Select callsign display method
 //==========================================================================================================//
 
 void create_menu_entry_showcall_screen(void)
@@ -836,6 +882,27 @@ void create_menu_entry_showcall_screen(void)
     
     mn_submenu_finalize();
 }
+
+
+//==========================================================================================================//
+// sub menu: Keyb Mode - Setup keyboard mode
+//==========================================================================================================//
+
+void create_menu_entry_keybmode_screen(void)
+{
+    mn_submenu_init(wt_keyb_mode);
+
+    md380_menu_entry_selected = global_addl_config.keyb_mode;
+
+    mn_submenu_add(wt_keyb_legacy, create_menu_entry_keyb_mode_legacy_screen);
+    mn_submenu_add(wt_keyb_modern, create_menu_entry_keyb_mode_modern_screen);
+    mn_submenu_add(wt_keyb_MD446, create_menu_entry_keyb_mode_MD446_screen);
+    mn_submenu_add(wt_keyb_dev, create_menu_entry_keyb_mode_dev_screen);
+    
+    mn_submenu_finalize();
+}
+
+//==========================================================================================================//
 
 void create_menu_entry_debug_screen(void)
 {
@@ -1178,22 +1245,44 @@ void select_sidebutton_function_screen(void)
 #warning Side Buttons not supported on D02 firmware
 #endif
 
+//==========================================================================================================//
+// sub menu: Side Button - Setup button assignments
+//==========================================================================================================//
+
+
 void create_menu_entry_sidebutton_screen(void)
 {
 #if defined(FW_D13_020) || defined(FW_S13_020)
 
    md380_menu_entry_selected = 0;
-    mn_submenu_init(wt_sidebutton_menu);
+   mn_submenu_init(wt_sidebutton_menu);
 
-    mn_submenu_add_98(wt_button_top_press, select_sidebutton_function_screen);
-    mn_submenu_add_98(wt_button_bot_press, select_sidebutton_function_screen);
-    mn_submenu_add_98(wt_button_top_held, select_sidebutton_function_screen);
-    mn_submenu_add_98(wt_button_bot_held, select_sidebutton_function_screen);
+   mn_submenu_add_98(wt_button_top_press, select_sidebutton_function_screen);
+   mn_submenu_add_98(wt_button_bot_press, select_sidebutton_function_screen);
+   mn_submenu_add_98(wt_button_top_held, select_sidebutton_function_screen);
+   mn_submenu_add_98(wt_button_bot_held, select_sidebutton_function_screen);
 
-    mn_submenu_finalize2();
+   mn_submenu_finalize2();
 #endif
 }
 
+//==========================================================================================================//
+// main menu: Keyb Setup - Keyboard relevant settings and assignments
+//==========================================================================================================//
+
+void create_menu_entry_keyboard_screen(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_keyb_menu);
+
+   mn_submenu_add_98(wt_keyb_mode, create_menu_entry_keybmode_screen);
+   mn_submenu_add_98(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
+
+   mn_submenu_finalize2();
+#endif
+}
 
 void create_menu_entry_backlight_screen(void)
 {
@@ -1767,18 +1856,21 @@ void create_menu_entry_addl_functions_screen(void)
 //==================================================================//
 //  MD380Tools - Menu order (often used functions top and bottom!)
 //  --------------------------------------------------------------
+//  Caution: the menu is limited to max. 17 entries!!
+//
 //   1 M. RogerBeep
 //   2 Boot Options
 //   3 Date Format
 //   4 Show Calls 
 //   ---------------
-//   5 USB logging 
-//   6 Promiscous
-//   7 Edit DMR-ID
-//   8 Morse output
+//   5 Keyb setup
+//   6 USB logging 
+//   7 Promiscuous
+//   8 Edit DMR-ID
 //   ---------------
-//   9 Config Reset
-//  10 Experimental
+//   9 Morse output
+//  10 Config Reset
+//  11 Experimental
 //  11 Mic bargraph
 //  12 Mic gain
 //   ---------------
@@ -1789,27 +1881,27 @@ void create_menu_entry_addl_functions_screen(void)
 //  17 Dev Only
 //==================================================================//
 
-// page 1
+// first page - MD380Tools - cursor down
     mn_submenu_add_98(wt_rbeep, create_menu_entry_rbeep_screen);
     mn_submenu_add(wt_bootopts, create_menu_entry_bootopts_screen);
     mn_submenu_add_98(wt_datef, create_menu_entry_datef_screen);
     mn_submenu_add_98(wt_showcall, create_menu_entry_showcall_screen);
-// page 2
+// setup pages - further functions
+//    mn_submenu_add_98(wt_keyb_setup, create_menu_entry_keybmode_screen);
+    mn_submenu_add(wt_keyb_menu, create_menu_entry_keyboard_screen);
     mn_submenu_add_98(wt_debug, create_menu_entry_debug_screen);
     mn_submenu_add_98(wt_promtg, create_menu_entry_promtg_screen);
     mn_submenu_add_8a(wt_edit, create_menu_entry_edit_screen, 0); // disable this menu entry - no function jet
     mn_submenu_add_8a(wt_edit_dmr_id, create_menu_entry_edit_dmr_id_screen, 1);
-
 #  if( CONFIG_MORSE_OUTPUT )
     mn_submenu_add(wt_morse_menu, create_menu_entry_morse_screen);
-#  endif   
-// page 3
+#  endif
     mn_submenu_add_98(wt_config_reset, mn_config_reset);
     mn_submenu_add_8a(wt_experimental, create_menu_entry_experimental_screen, 1);
     mn_submenu_add_98(wt_micbargraph, create_menu_entry_micbargraph_screen);
     mn_submenu_add_98(wt_micgain, create_menu_entry_micgain_screen);
-// page 4
-    mn_submenu_add(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
+//    mn_submenu_add(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
+// last page - MD380Tools - cursor up 
     mn_submenu_add(wt_backlight_menu, create_menu_entry_backlight_screen);
     mn_submenu_add_8a(wt_set_tg_id, create_menu_entry_set_tg_screen, 1);
     mn_submenu_add_98(wt_cp_override, mn_cp_override);    

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -26,6 +26,8 @@
 #include "keyb.h"
 #include "codeplug.h"
 #include "narrator.h" // optional: reads out channel, zone, menu in Morse code.
+#include "system_hrc5000.h"
+
 // Main menu name
 const static wchar_t wt_main_menu[]         = L"MD380Tools";	// MD380Tools menu name
 const static wchar_t wt_main_menutxt[]      = L"MD380Tools 2.0";// MD380Tools menu header
@@ -44,19 +46,13 @@ const static wchar_t wt_dmr_menu[]          = L"DMR Setup";	// sub menu 4 header
 const static wchar_t wt_tones_menu[]        = L"Tones/Audio";	// sub menu 5 header title
 const static wchar_t wt_dev_menu[]          = L"Developer";	// sub menu 6 header title
 
-const static wchar_t wt_datef[]             = L"Date format";
-const static wchar_t wt_debug[]             = L"USB logging";
-const static wchar_t wt_netmon[]            = L"NetMonitor";
-//const static wchar_t wt_netmon[]            = L"DevOnly!!"; // for now, later a true submenu.
-const static wchar_t wt_disable[]           = L"Disable";
-const static wchar_t wt_enable[]            = L"Enable";
-const static wchar_t wt_rbeep[]             = L"M. RogerBeep";
+const static wchar_t wt_enable[]            = L"Enable";	// general option used in several menus
+const static wchar_t wt_disable[]           = L"Disable";	// general option used in several menus
 
 const static wchar_t wt_bootopts[]          = L"Boot Options";
 const static wchar_t wt_demoscr[]           = L"Demo Screen";
-const static wchar_t wt_demoscr_enable[]    = L"Enable";
-const static wchar_t wt_demoscr_disable[]   = L"Disable";
 const static wchar_t wt_splash[]            = L"Splash Mode";
+const static wchar_t wt_rbeep[]             = L"M. RogerBeep";
 
 const static wchar_t wt_showcall[]          = L"Show Calls";    // was UsersCSV / enable / disable now added Talker Alias
 const static wchar_t wt_fromcps[]           = L"CPS only";
@@ -70,20 +66,27 @@ const static wchar_t wt_keyb_modern[]       = L"Modern";	// Modern keyb layout, 
 const static wchar_t wt_keyb_MD446[]        = L"MD-446";	// Tytera MD-446 special 6-key layout, no numeric keypad
 const static wchar_t wt_keyb_dev[]          = L"Develop";	// Developer mode
 
+const static wchar_t wt_keyb_scroll[]       = L"Scroll Mode"; 	// scroll mode - enable or disable 
+const static wchar_t wt_scroll_off[]        = L"Scroll Off";	// disable scrolling
+const static wchar_t wt_scroll_fast[]       = L"Scroll Fast";	// enable fast scroll mode
+const static wchar_t wt_scroll_slow[]       = L"Scroll Slow";	// enable slow scroll mode
+
+const static wchar_t wt_datef[]             = L"Date/Status";	// sub menu header title
 const static wchar_t wt_datef_original[]    = L"YYYY/MM/DD";
 const static wchar_t wt_datef_germany[]     = L"DD.MM.YYYY";
 const static wchar_t wt_datef_italy[]       = L"DD/MM/YYYY";
 const static wchar_t wt_datef_american[]    = L"MM/DD/YYYY";
 const static wchar_t wt_datef_iso[]         = L"YYYY-MM-DD";
-const static wchar_t wt_datef_alt[]         = L"Lastheard ";
-const static wchar_t wt_datef_talias[]      = L"Talker Alias";    // added Talker Alias 
+const static wchar_t wt_datef_alt[]         = L"Lastheard ";	// show lastheard in statusline instead of date/time
+const static wchar_t wt_datef_talias[]      = L"Talker Alias";	// show Talker Alias in statusline instead of date/time
 
+const static wchar_t wt_set_tg_id[]         = L"Set Talkgroup";	// brad's PR #708
+const static wchar_t wt_netmon[]            = L"NetMonitor";
 const static wchar_t wt_promtg[]            = L"Promiscuous";
 const static wchar_t wt_edit[]              = L"Edit";
 const static wchar_t wt_edit_dmr_id[]       = L"Edit DMR-ID";
 const static wchar_t wt_no_w25q128[]        = L"No W25Q128";
-const static wchar_t wt_set_tg_id[]         = L"Set Talkgroup"; // brad's PR #708 
-const static wchar_t wt_experimental[]      = L"Experimental";
+
 const static wchar_t wt_micbargraph[]       = L"Mic bargraph";
 
 const static wchar_t wt_backlight[]         = L"Backlight Tmr";
@@ -92,9 +95,51 @@ const static wchar_t wt_bl5[]               = L"5 sec";
 const static wchar_t wt_bl30[]              = L"30 sec";
 const static wchar_t wt_bl60[]              = L"60 sec";
 
+const static wchar_t wt_fm_bpf[]	    = L"Bandpass Filter";
+const static wchar_t wt_fm_bpf_on[]         = L"FM BPF On";
+const static wchar_t wt_fm_bpf_off[]        = L"FM BPF Off";
+
+const static wchar_t wt_fm_comp[]	    = L"FM Compressor";
+const static wchar_t wt_fm_comp_on[]        = L"Mic Comp. On";
+const static wchar_t wt_fm_comp_off[]       = L"Mic Comp. Off";
+
+const static wchar_t wt_fm_preemp[]	    = L"FM PreEmphasis";
+const static wchar_t wt_fm_preemp_on[]      = L"PreEmph. On";
+const static wchar_t wt_fm_preemp_off[]     = L"PreEmph. Off";
+
+const static wchar_t wt_fm_bw[]		    = L"FM Bandwidth";
+const static wchar_t wt_fm_bw_12kHz[]       = L"12.5kHz";
+const static wchar_t wt_fm_bw_25kHz[]       = L"25.0kHZ";
+
+const static wchar_t wt_fm_options[]	    = L"FM Options";
+const static wchar_t wt_fm_save[]	    = L"Save setup";
+const static wchar_t wt_fm_reset_all[]	    = L"Reset all";
+
+const static wchar_t wt_fm_dev[]	    = L"FM Deviation";
+const static wchar_t wt_fm_dev0[]	    = L"Level -3";
+const static wchar_t wt_fm_dev1[]	    = L"Level -2";
+const static wchar_t wt_fm_dev2[]	    = L"Level -1";
+const static wchar_t wt_fm_dev3[]	    = L"Default";
+const static wchar_t wt_fm_dev4[]	    = L"Level +1";
+const static wchar_t wt_fm_dev5[]	    = L"Level +2";
+const static wchar_t wt_fm_dev6[]	    = L"Level +3";
+
 const static wchar_t wt_micgain[]           = L"Mic gain";
 const static wchar_t wt_micgain_3db[]       = L"3db Gain";
 const static wchar_t wt_micgain_6db[]       = L"6db Gain";
+
+const static wchar_t wt_debug[]             = L"USB logging";
+const static wchar_t wt_experimental[]      = L"Experimental";
+const static wchar_t wt_cp_override[]       = L"CoPl Override";
+//const static wchar_t wt_netmon[]            = L"DevOnly!!"; // for now, later a true submenu.
+const static wchar_t wt_config_reset[]	    = L"Config Reset";
+const static wchar_t wt_config_reset_doit[] = L"Config Reset2";
+
+const static wchar_t wt_dev_mode[]	    = L"DevMode Level";
+const static wchar_t wt_dev_mode0[]	    = L"Standard";	 // devmode_level = 0
+const static wchar_t wt_dev_mode1[]	    = L"Ext. FM setup";	 // devmode_level = 1
+const static wchar_t wt_dev_mode2[]	    = L"USB verbose";	 // devmode_level = 2
+const static wchar_t wt_dev_mode3[]	    = L"Short Menu";	 // devmode_level = 3
 
 
 const static wchar_t wt_backlight_menu[]    = L"Backlight";
@@ -115,15 +160,12 @@ const static wchar_t *wt_bl_intensity[NUM_BACKLIGHT_INTENSITIES] =
    L"5",       L"6",          L"7", L"8",          L"9 (bright)" }; 
 #endif // CONFIG_DIMMED_LIGHT ?
 
-const static wchar_t wt_cp_override[]       = L"CoPl Override";
 const static wchar_t wt_splash_manual[]     = L"Disabled";
 const static wchar_t wt_splash_callid[]     = L"Callsign+DMRID";
 const static wchar_t wt_splash_callname[]   = L"Callsign+Name";
 
 const static wchar_t wt_cp_override_dmrid[] = L"ID Override";
 
-const static wchar_t wt_config_reset[] = L"Config Reset";
-const static wchar_t wt_config_reset_doit[] = L"Config Reset2";
 
 const static wchar_t wt_sidebutton_menu[]   = L"Side Buttons";
 const static wchar_t wt_button_top_press[]  = L"Top Pressed";
@@ -482,12 +524,15 @@ void create_menu_entry_demo_screen(void)
 
     md380_menu_entry_selected = global_addl_config.boot_demo;
 
-    mn_submenu_add(wt_demoscr_enable, create_menu_entry_demo_enable_screen);
-    mn_submenu_add(wt_demoscr_disable, create_menu_entry_demo_disable_screen);
+    mn_submenu_add(wt_enable, create_menu_entry_demo_enable_screen);
+    mn_submenu_add(wt_disable, create_menu_entry_demo_disable_screen);
 
     mn_submenu_finalize();
 }
 
+//==========================================================================================================//
+// options: Mic gain - set mic gain - off/3dB/6dB
+//==========================================================================================================//
 
 void create_menu_entry_micgain_6db_screen(void)
 {
@@ -515,12 +560,158 @@ void create_menu_entry_micgain_screen(void)
 	mn_submenu_init(wt_micgain);
 
 	md380_menu_entry_selected = global_addl_config.mic_gain;
-	mn_submenu_add(wt_demoscr_disable, create_menu_entry_micgain_disable_screen);
+	mn_submenu_add(wt_disable, create_menu_entry_micgain_disable_screen);
 	mn_submenu_add(wt_micgain_3db, create_menu_entry_micgain_3db_screen);
 	mn_submenu_add(wt_micgain_6db, create_menu_entry_micgain_6db_screen);
 
 	mn_submenu_finalize();
 }
+
+//==========================================================================================================//
+// options: FM settings - bandpass/compression/preemphasis/bandwith
+//==========================================================================================================//
+void mn_option_fm_bpf_off(void)
+{
+    mn_create_single_timed_ack(wt_fm_bpf, wt_fm_bpf_off);
+    global_addl_config.fm_bpf = 0;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void mn_option_fm_bpf_on(void)
+{
+    mn_create_single_timed_ack(wt_fm_bpf, wt_fm_bpf_on);
+    global_addl_config.fm_bpf = 1;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void create_menu_fm_bpf(void)
+{
+	mn_submenu_init(wt_fm_bpf);
+
+	md380_menu_entry_selected = global_addl_config.fm_bpf;
+	mn_submenu_add(wt_fm_bpf_off, mn_option_fm_bpf_off);
+	mn_submenu_add(wt_fm_bpf_on, mn_option_fm_bpf_on);
+
+	mn_submenu_finalize();
+}
+//--------------------------------------------------------------------------------------------------------//
+void mn_option_fm_comp_off(void)
+{
+    mn_create_single_timed_ack(wt_fm_comp, wt_fm_comp_off);
+    global_addl_config.fm_comp = 0;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void mn_option_fm_comp_on(void)
+{
+    mn_create_single_timed_ack(wt_fm_comp, wt_fm_comp_on);
+    global_addl_config.fm_comp = 1;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void create_menu_fm_comp(void)
+{
+	mn_submenu_init(wt_fm_comp);
+
+	md380_menu_entry_selected = global_addl_config.fm_comp;
+	mn_submenu_add(wt_fm_comp_off, mn_option_fm_comp_off);
+	mn_submenu_add(wt_fm_comp_on, mn_option_fm_comp_on);
+
+	mn_submenu_finalize();
+}
+//--------------------------------------------------------------------------------------------------------//
+void mn_option_fm_preemp_off(void)
+{
+    mn_create_single_timed_ack(wt_fm_preemp, wt_fm_preemp_off);
+    global_addl_config.fm_preemp = 0;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void mn_option_fm_preemp_on(void)
+{
+    mn_create_single_timed_ack(wt_fm_preemp, wt_fm_preemp_on);
+    global_addl_config.fm_preemp = 1;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void create_menu_fm_preemp(void)
+{
+	mn_submenu_init(wt_fm_preemp);
+
+	md380_menu_entry_selected = global_addl_config.fm_preemp;
+	mn_submenu_add(wt_fm_preemp_off, mn_option_fm_preemp_off);
+	mn_submenu_add(wt_fm_preemp_on, mn_option_fm_preemp_on);
+
+	mn_submenu_finalize();
+}
+//--------------------------------------------------------------------------------------------------------//
+void mn_option_fm_bw_12kHz(void)
+{
+    mn_create_single_timed_ack(wt_fm_bw, wt_fm_bw_12kHz);
+    global_addl_config.fm_bw = 0;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void mn_option_fm_bw_25kHz(void)
+{
+    mn_create_single_timed_ack(wt_fm_bw, wt_fm_bw_25kHz);
+    global_addl_config.fm_bw = 1;
+    global_addl_config.fm_mode = 0xFF;			// set change flag
+    cfg_save();
+}
+
+void create_menu_fm_bw(void)
+{
+	mn_submenu_init(wt_fm_bw);
+
+	md380_menu_entry_selected = global_addl_config.fm_bw;
+	mn_submenu_add(wt_fm_bw_12kHz, mn_option_fm_bw_12kHz);
+	mn_submenu_add(wt_fm_bw_25kHz, mn_option_fm_bw_25kHz);
+
+	mn_submenu_finalize();
+}
+//--------------------------------------------------------------------------------------------------------//
+void mn_option_fm_save(void)
+{
+    mn_create_single_timed_ack(wt_fm_options, wt_fm_save);
+    hrc5000_fm_read();				// read hrc fm register and log
+
+    cfg_save();
+}
+
+void mn_option_fm_reset_all(void)
+{
+    mn_create_single_timed_ack(wt_fm_options, wt_fm_reset_all);
+
+    global_addl_config.fm_bpf = 1;		// reset bandpass filter to default
+    global_addl_config.fm_comp = 1;		// reset compressor to default
+    global_addl_config.fm_preemp = 1;		// reset pre-emphasis to default
+    global_addl_config.fm_bw = 1;		// reset bandwidth to default
+    global_addl_config.fm_dev = 3;		// reset deviation to default
+
+    cfg_save();
+    hrc5000_fm_reset();				// write default values to register 0x34, 0x35
+}
+
+void create_menu_fm_options(void)
+{
+	mn_submenu_init(wt_fm_options);
+
+	md380_menu_entry_selected = 0;
+	mn_submenu_add(wt_fm_save, mn_option_fm_save);
+	mn_submenu_add(wt_fm_reset_all, mn_option_fm_reset_all);
+
+	mn_submenu_finalize();
+}
+
+//==========================================================================================================//
 
 void mn_cp_override_off(void)
 {
@@ -618,8 +809,8 @@ void mn_cp_override_dmrid_off(void)
 void mn_cp_override_dmrid(void)
 {
     mn_submenu_init(wt_cp_override_dmrid);
-    mn_submenu_add(wt_demoscr_enable, mn_cp_override_dmrid_on);
-    mn_submenu_add(wt_demoscr_disable, mn_cp_override_dmrid_off);
+    mn_submenu_add(wt_enable, mn_cp_override_dmrid_on);
+    mn_submenu_add(wt_disable, mn_cp_override_dmrid_off);
     mn_submenu_finalize();
 }
 
@@ -790,6 +981,124 @@ void create_menu_entry_keyb_mode_dev_screen(void)
 
 //==========================================================================================================//
 
+//==========================================================================================================//
+// submenu: Keyb scrolling - select scroll mode
+//==========================================================================================================//
+
+void menu_entry_scroll_mode_off(void)
+{
+    mn_create_single_timed_ack(wt_keyb_scroll,wt_scroll_off);
+    global_addl_config.scroll_mode = 0;
+    cfg_save();
+}
+
+void menu_entry_scroll_mode_fast(void)
+{
+    mn_create_single_timed_ack(wt_keyb_scroll,wt_scroll_fast);
+    global_addl_config.scroll_mode = 1;
+    cfg_save();
+}
+
+void menu_entry_scroll_mode_slow(void)
+{
+    mn_create_single_timed_ack(wt_keyb_scroll,wt_scroll_slow);
+    global_addl_config.scroll_mode = 2;
+    cfg_save();
+}
+
+//==========================================================================================================//
+
+//==========================================================================================================//
+// submenu: FM deviation setup - select FM modulation level
+//==========================================================================================================//
+
+void mn_option_fm_dev0(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev0);
+    global_addl_config.fm_dev = 0;
+    cfg_save();
+}
+
+void mn_option_fm_dev1(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev1);
+    global_addl_config.fm_dev = 1;
+    cfg_save();
+}
+
+void mn_option_fm_dev2(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev2);
+    global_addl_config.fm_dev = 2;
+    cfg_save();
+}
+
+void mn_option_fm_dev3(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev3);
+    global_addl_config.fm_dev = 3;
+    cfg_save();
+}
+
+void mn_option_fm_dev4(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev4);
+    global_addl_config.fm_dev = 4;
+    cfg_save();
+}
+
+void mn_option_fm_dev5(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev5);
+    global_addl_config.fm_dev = 5;
+    cfg_save();
+}
+
+void mn_option_fm_dev6(void)
+{
+    mn_create_single_timed_ack(wt_fm_dev,wt_fm_dev6);
+    global_addl_config.fm_dev = 6;
+    cfg_save();
+}
+
+
+//==========================================================================================================//
+
+
+//==========================================================================================================//
+// submenu: Developer mode - select developer mode level
+//==========================================================================================================//
+
+void mn_option_dev_mode0(void)
+{
+    mn_create_single_timed_ack(wt_dev_mode,wt_dev_mode0);
+    global_addl_config.devmode_level = 0;
+    cfg_save();
+}
+
+void mn_option_dev_mode1(void)
+{
+    mn_create_single_timed_ack(wt_dev_mode,wt_dev_mode1);
+    global_addl_config.devmode_level = 1;
+    cfg_save();
+}
+
+void mn_option_dev_mode2(void)
+{
+    mn_create_single_timed_ack(wt_dev_mode,wt_dev_mode2);
+    global_addl_config.devmode_level = 2;
+    cfg_save();
+}
+
+void mn_option_dev_mode3(void)
+{
+    mn_create_single_timed_ack(wt_dev_mode,wt_dev_mode3);
+    global_addl_config.devmode_level = 3;
+    cfg_save();
+}
+
+//==========================================================================================================//
+
 void create_menu_entry_experimental_enable_screen(void)
 {
     mn_create_single_timed_ack(wt_experimental,wt_enable);
@@ -926,6 +1235,50 @@ void create_menu_entry_keybmode_screen(void)
 }
 
 //==========================================================================================================//
+
+//==========================================================================================================//
+// sub menu: Keyb scroll mode - Setup keyboard scrolling
+//==========================================================================================================//
+
+void create_menu_entry_scroll_mode(void)
+{
+    mn_submenu_init(wt_keyb_scroll);
+
+    md380_menu_entry_selected = global_addl_config.scroll_mode;
+
+    mn_submenu_add(wt_scroll_off, menu_entry_scroll_mode_off);
+    mn_submenu_add(wt_scroll_fast, menu_entry_scroll_mode_fast);
+    mn_submenu_add(wt_scroll_slow, menu_entry_scroll_mode_slow);
+    
+    mn_submenu_finalize();
+}
+
+//==========================================================================================================//
+
+
+//==========================================================================================================//
+// sub menu: FM Deviation - Setup FM modulation
+//==========================================================================================================//
+
+void create_menu_fm_deviation(void)
+{
+	mn_submenu_init(wt_fm_dev);
+
+	md380_menu_entry_selected = global_addl_config.fm_dev;
+
+	mn_submenu_add(wt_fm_dev0, mn_option_fm_dev0);
+	mn_submenu_add(wt_fm_dev1, mn_option_fm_dev1);
+	mn_submenu_add(wt_fm_dev2, mn_option_fm_dev2);
+	mn_submenu_add(wt_fm_dev3, mn_option_fm_dev3);
+	mn_submenu_add(wt_fm_dev4, mn_option_fm_dev4);
+	mn_submenu_add(wt_fm_dev5, mn_option_fm_dev5);
+	mn_submenu_add(wt_fm_dev6, mn_option_fm_dev6);
+
+	mn_submenu_finalize();
+}
+
+//==========================================================================================================//
+
 
 void create_menu_entry_debug_screen(void)
 {
@@ -1585,6 +1938,33 @@ void mn_config_reset(void)
     mn_submenu_finalize();
 }
 
+//==========================================================================================================//
+// sub menu: Developer mode - select developer mode
+//==========================================================================================================//
+void mn_dev_mode(void)
+{
+	mn_submenu_init(wt_dev_mode);
+
+	md380_menu_entry_selected = global_addl_config.devmode_level;
+
+	mn_submenu_add(wt_dev_mode0, mn_option_dev_mode0);
+	mn_submenu_add(wt_dev_mode1, mn_option_dev_mode1);
+							// the FM setup / deviation level settings are very
+							// experimental features. They will we added to the
+							// radio menu, only if devmode 1 has been selected!
+							
+	if (global_addl_config.devmode_level > 0) {	// show next menu level only if devmode 1 enabled
+		mn_submenu_add(wt_dev_mode2, mn_option_dev_mode2);
+	}
+	if (global_addl_config.devmode_level > 1) {	// show next menu level only if devmode 2 enabled
+		mn_submenu_add(wt_dev_mode3, mn_option_dev_mode3);
+	}
+
+	mn_submenu_finalize();
+}
+//==========================================================================================================//
+
+
 void create_menu_entry_edit_screen_store(void)
 {
 #if 0
@@ -1878,6 +2258,7 @@ void create_menu_entry_keyboard(void)
 
    mn_submenu_add_98(wt_keyb_mode, create_menu_entry_keybmode_screen);
    mn_submenu_add_98(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
+   mn_submenu_add_98(wt_keyb_scroll, create_menu_entry_scroll_mode);
 
    mn_submenu_finalize2();
 #endif
@@ -1894,10 +2275,25 @@ void create_menu_entry_radio(void)
 
    md380_menu_entry_selected = 0;
    mn_submenu_init(wt_radio_menu);
-
+							// for rapid access to the radio menu during development
+							// the first 3 options will be removed from radio menu
+							// when devmode=3 was activated in MD380Tools (menu 4-6-5)
+   if (global_addl_config.devmode_level < 3) {		// DL2MF - remove after development! #################
    mn_submenu_add_98(wt_backlight_menu, create_menu_entry_backlight_screen);
    mn_submenu_add_98(wt_micbargraph, create_menu_entry_micbargraph_screen);
    mn_submenu_add_98(wt_micgain, create_menu_entry_micgain_screen);
+   }
+							// the FM setup / deviation level settings are very
+							// experimental features. They will we added to the
+							// radio menu, only if devmode 1 has been selected!
+   if (global_addl_config.devmode_level > 0) {		// DL2MF - remove after development! #################
+   mn_submenu_add_98(wt_fm_bpf, create_menu_fm_bpf);
+   mn_submenu_add_98(wt_fm_comp, create_menu_fm_comp);
+   mn_submenu_add_98(wt_fm_preemp, create_menu_fm_preemp);
+   mn_submenu_add_98(wt_fm_bw, create_menu_fm_bw);
+   mn_submenu_add_98(wt_fm_dev, create_menu_fm_deviation);
+   mn_submenu_add_98(wt_fm_options, create_menu_fm_options);
+   }
 
    mn_submenu_finalize2();
 #endif
@@ -1961,6 +2357,7 @@ void create_menu_entry_dev(void)
    mn_submenu_add_8a(wt_experimental, create_menu_entry_experimental_screen, 1);
    mn_submenu_add_98(wt_cp_override, mn_cp_override); 
    mn_submenu_add_98(wt_config_reset, mn_config_reset);
+   mn_submenu_add_98(wt_dev_mode, mn_dev_mode);
 
    mn_submenu_finalize2();
 #endif
@@ -2025,11 +2422,15 @@ void create_main_md380tools_screen(void)
     PRINTRET();
     PRINT("create_main_menu_screen\n");
 
+    if (global_addl_config.devmode_level < 3) {		// DL2MF - remove after development! #################
     mn_submenu_add_98(wt_main_display, create_menu_entry_display);
     mn_submenu_add_98(wt_main_keyb, create_menu_entry_keyboard);
+    }
     mn_submenu_add_98(wt_main_radio, create_menu_entry_radio);
     mn_submenu_add_98(wt_main_dmr, create_menu_entry_dmr);
+    if (global_addl_config.devmode_level < 3) {		// DL2MF - remove after development! #################
     mn_submenu_add_98(wt_main_tones, create_menu_entry_tones);
+    }
     mn_submenu_add_98(wt_main_dev, create_menu_entry_dev);    
 
     mn_submenu_finalize2();

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -26,12 +26,28 @@
 #include "keyb.h"
 #include "codeplug.h"
 #include "narrator.h" // optional: reads out channel, zone, menu in Morse code.
+// Main menu name
+const static wchar_t wt_main_menu[]         = L"MD380Tools";	// MD380Tools menu name
+const static wchar_t wt_main_menutxt[]      = L"MD380Tools 2.0";// MD380Tools menu header
+// Main menu entries 
+const static wchar_t wt_main_display[]      = L"Display";	// main menu 1 - display options
+const static wchar_t wt_main_keyb[]         = L"Keyboard";	// main menu 2 - keyboard options
+const static wchar_t wt_main_radio[]        = L"Radio";		// main menu 3 - radio options
+const static wchar_t wt_main_dmr[]          = L"DMR";		// main menu 4 - dmr settings
+const static wchar_t wt_main_tones[]        = L"Tones";		// main menu 5 - tone settings
+const static wchar_t wt_main_dev[]          = L"Developer";	// main menu 6 - developer menu
+// Sub menu header
+const static wchar_t wt_disp_menu[]         = L"Display Setup";	// sub menu 1 header title
+const static wchar_t wt_keyb_menu[]         = L"Keyboard Setup";// sub menu 2 header title
+const static wchar_t wt_radio_menu[]        = L"Radio Setup";	// sub menu 3 header title
+const static wchar_t wt_dmr_menu[]          = L"DMR Setup";	// sub menu 4 header title
+const static wchar_t wt_tones_menu[]        = L"Tones/Audio";	// sub menu 5 header title
+const static wchar_t wt_dev_menu[]          = L"Developer";	// sub menu 6 header title
 
-const static wchar_t wt_addl_func[]         = L"MD380Tools";
 const static wchar_t wt_datef[]             = L"Date format";
 const static wchar_t wt_debug[]             = L"USB logging";
-//const static wchar_t wt_netmon[]            = L"NetMon";
-const static wchar_t wt_netmon[]            = L"DevOnly!!"; // for now, later a true submenu.
+const static wchar_t wt_netmon[]            = L"NetMonitor";
+//const static wchar_t wt_netmon[]            = L"DevOnly!!"; // for now, later a true submenu.
 const static wchar_t wt_disable[]           = L"Disable";
 const static wchar_t wt_enable[]            = L"Enable";
 const static wchar_t wt_rbeep[]             = L"M. RogerBeep";
@@ -48,7 +64,6 @@ const static wchar_t wt_usercsv[]           = L"User DB";
 const static wchar_t wt_talkalias[]         = L"Talk Alias";
 const static wchar_t wt_ta_user[]           = L"TA & UserDB";
 
-const static wchar_t wt_keyb_menu[]         = L"Keyb setting";	// main menu - setup side buttons and keyb layout mode
 const static wchar_t wt_keyb_mode[]         = L"Keyb Mode";     // keyb setup - select for different layout and radio models
 const static wchar_t wt_keyb_legacy[]       = L"Legacy";	// Tradiotionally layout of first MD380Tools firmware 
 const static wchar_t wt_keyb_modern[]       = L"Modern";	// Modern keyb layout, reordered functions, special keys right column
@@ -1274,24 +1289,6 @@ void create_menu_entry_sidebutton_screen(void)
 #endif
 }
 
-//==========================================================================================================//
-// main menu: Keyb Setup - Keyboard relevant settings and assignments
-//==========================================================================================================//
-
-void create_menu_entry_keyboard_screen(void)
-{
-#if defined(FW_D13_020) || defined(FW_S13_020)
-
-   md380_menu_entry_selected = 0;
-   mn_submenu_init(wt_keyb_menu);
-
-   mn_submenu_add_98(wt_keyb_mode, create_menu_entry_keybmode_screen);
-   mn_submenu_add_98(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
-
-   mn_submenu_finalize2();
-#endif
-}
-
 void create_menu_entry_backlight_screen(void)
 {
 #if defined(FW_D13_020) || defined(FW_S13_020)
@@ -1847,9 +1844,176 @@ void create_menu_entry_set_tg_screen(void)
 #endif // D13_020, S13_020, ..(?)
 }
 
-void create_menu_entry_addl_functions_screen(void)
+//==========================================================================================================//
+// main menu 1: Display - Display relevant settings and assignments
+//==========================================================================================================//
+
+void create_menu_entry_display(void)
 {
-    mn_submenu_init(wt_addl_func);
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_disp_menu);
+
+   mn_submenu_add_98(wt_backlight_menu, create_menu_entry_backlight_screen);
+   mn_submenu_add_98(wt_datef, create_menu_entry_datef_screen);
+   mn_submenu_add_98(wt_showcall, create_menu_entry_showcall_screen);
+   mn_submenu_add_98(wt_bootopts, create_menu_entry_bootopts_screen);
+
+   mn_submenu_finalize2();
+#endif
+}
+//==========================================================================================================//
+
+//==========================================================================================================//
+// main menu 2: Keyboard - Keyboard relevant settings and assignments
+//==========================================================================================================//
+
+void create_menu_entry_keyboard(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_keyb_menu);
+
+   mn_submenu_add_98(wt_keyb_mode, create_menu_entry_keybmode_screen);
+   mn_submenu_add_98(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
+
+   mn_submenu_finalize2();
+#endif
+}
+//==========================================================================================================//
+
+//==========================================================================================================//
+// main menu 3: Radio - Radio relevant settings and assignments
+//==========================================================================================================//
+
+void create_menu_entry_radio(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_radio_menu);
+
+   mn_submenu_add_98(wt_backlight_menu, create_menu_entry_backlight_screen);
+   mn_submenu_add_98(wt_micbargraph, create_menu_entry_micbargraph_screen);
+   mn_submenu_add_98(wt_micgain, create_menu_entry_micgain_screen);
+
+   mn_submenu_finalize2();
+#endif
+}
+//==========================================================================================================//
+
+//==========================================================================================================//
+// main menu 4: DMR Setup - DMR relevant settings and assignments
+//==========================================================================================================//
+
+void create_menu_entry_dmr(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_dmr_menu);
+
+   mn_submenu_add_8a(wt_set_tg_id, create_menu_entry_set_tg_screen, 1);
+   mn_submenu_add_98(wt_netmon, create_menu_entry_netmon_screen);
+   mn_submenu_add_98(wt_promtg, create_menu_entry_promtg_screen);
+   mn_submenu_add_8a(wt_edit_dmr_id, create_menu_entry_edit_dmr_id_screen, 1);
+
+   mn_submenu_finalize2();
+#endif
+}
+//==========================================================================================================//
+
+//==========================================================================================================//
+// main menu 5: Tones - Tones and audio feedback functions
+//==========================================================================================================//
+
+void create_menu_entry_tones(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_tones_menu);
+
+    mn_submenu_add_98(wt_rbeep, create_menu_entry_rbeep_screen);
+#  if( CONFIG_MORSE_OUTPUT )
+    mn_submenu_add_98(wt_morse_menu, create_menu_entry_morse_screen);
+#  endif
+
+   mn_submenu_finalize2();
+#endif
+}
+//==========================================================================================================//
+
+//==========================================================================================================//
+// main menu 6: Developer - Developer relevant and other settings and assignments
+//==========================================================================================================//
+
+void create_menu_entry_dev(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+   md380_menu_entry_selected = 0;
+   mn_submenu_init(wt_dev_menu);
+
+   mn_submenu_add_98(wt_debug, create_menu_entry_debug_screen);
+   mn_submenu_add_8a(wt_experimental, create_menu_entry_experimental_screen, 1);
+   mn_submenu_add_98(wt_cp_override, mn_cp_override); 
+   mn_submenu_add_98(wt_config_reset, mn_config_reset);
+
+   mn_submenu_finalize2();
+#endif
+}
+//==========================================================================================================//
+
+//==========================================================================================================//
+// MD380Tools - Main menu - Caution: the main menu is limited to max. 16 + 1 entries!!
+//==========================================================================================================//
+//  
+//   1 Display
+//	   !
+//	   +--- 1 Backlight
+//	   +--- 2 Statusline  
+//	   +--- 3 Show Calls 
+//	   +--- 4 Boot Options
+//
+//   2 Keyboard
+//	   !
+//	   +--- 1 Keyb mode
+//	   +--- 2 Side Buttons
+//
+//   3 Radio
+//	   !
+//	   +--- 1 Backlight		--> also in 1-1, may be removed here later
+//	   +--- 2 Mic bargraph
+//	   +--- 3 Mic gain
+//
+//   4 DMR Setup
+//	   !
+//	   +--- 1 Adhoc Talkgrp
+//	   +--- 2 Netmonitor		--> new mode required for this!
+//	   +--- 3 Promiscous
+//	   +--- 4 Edit DMR-ID
+// 
+//   5 Tones
+//	   !
+//	   +--- 1 Morse output
+//	   +--- 2 M. RogerBeep
+//
+//   6 Developer
+//	   !
+//	   +--- 1 USB logging 
+//	   +--- 2 Experimental
+//	   +--- 3 CoPl Override
+//	   +--- 4 Config Reset
+//	   +--- 5 Dev Only
+//
+//==================================================================//
+
+void create_main_md380tools_screen(void)
+{
+    mn_submenu_init(wt_main_menutxt);
     
 #  if 0
     register uint32_t * sp asm("sp");
@@ -1859,64 +2023,19 @@ void create_menu_entry_addl_functions_screen(void)
     //printf( "f menucall.%s 0 0x%x\n", lbl2, (sp[15] - 1 - 4) );
 #  endif    
     PRINTRET();
-    PRINT("create_menu_entry_addl_functions_screen\n");
+    PRINT("create_main_menu_screen\n");
 
-//==================================================================//
-//  MD380Tools - Menu order (often used functions top and bottom!)
-//  --------------------------------------------------------------
-//  Caution: the menu is limited to max. 17 entries!!
-//
-//   1 M. RogerBeep
-//   2 Boot Options
-//   3 Date Format
-//   4 Show Calls 
-//   ---------------
-//   5 Keyb setup
-//   6 USB logging 
-//   7 Promiscuous
-//   8 Edit DMR-ID
-//   ---------------
-//   9 Morse output
-//  10 Config Reset
-//  11 Experimental
-//  11 Mic bargraph
-//  12 Mic gain
-//   ---------------
-//  13 Side Buttons 
-//  14 Backlight
-//  15 Set Talkgroup
-//  16 CoPl Override
-//  17 Dev Only
-//==================================================================//
+    mn_submenu_add_98(wt_main_display, create_menu_entry_display);
+    mn_submenu_add_98(wt_main_keyb, create_menu_entry_keyboard);
+    mn_submenu_add_98(wt_main_radio, create_menu_entry_radio);
+    mn_submenu_add_98(wt_main_dmr, create_menu_entry_dmr);
+    mn_submenu_add_98(wt_main_tones, create_menu_entry_tones);
+    mn_submenu_add_98(wt_main_dev, create_menu_entry_dev);    
 
-// first page - MD380Tools - cursor down
-    mn_submenu_add_98(wt_rbeep, create_menu_entry_rbeep_screen);
-    mn_submenu_add(wt_bootopts, create_menu_entry_bootopts_screen);
-    mn_submenu_add_98(wt_datef, create_menu_entry_datef_screen);
-    mn_submenu_add_98(wt_showcall, create_menu_entry_showcall_screen);
-// setup pages - further functions
-//    mn_submenu_add_98(wt_keyb_setup, create_menu_entry_keybmode_screen);
-    mn_submenu_add(wt_keyb_menu, create_menu_entry_keyboard_screen);
-    mn_submenu_add_98(wt_debug, create_menu_entry_debug_screen);
-    mn_submenu_add_98(wt_promtg, create_menu_entry_promtg_screen);
-    mn_submenu_add_8a(wt_edit, create_menu_entry_edit_screen, 0); // disable this menu entry - no function jet
-    mn_submenu_add_8a(wt_edit_dmr_id, create_menu_entry_edit_dmr_id_screen, 1);
-#  if( CONFIG_MORSE_OUTPUT )
-    mn_submenu_add(wt_morse_menu, create_menu_entry_morse_screen);
-#  endif
-    mn_submenu_add_98(wt_config_reset, mn_config_reset);
-    mn_submenu_add_8a(wt_experimental, create_menu_entry_experimental_screen, 1);
-    mn_submenu_add_98(wt_micbargraph, create_menu_entry_micbargraph_screen);
-    mn_submenu_add_98(wt_micgain, create_menu_entry_micgain_screen);
-//    mn_submenu_add(wt_sidebutton_menu, create_menu_entry_sidebutton_screen);
-// last page - MD380Tools - cursor up 
-    mn_submenu_add(wt_backlight_menu, create_menu_entry_backlight_screen);
-    mn_submenu_add_8a(wt_set_tg_id, create_menu_entry_set_tg_screen, 1);
-    mn_submenu_add_98(wt_cp_override, mn_cp_override);    
-    mn_submenu_add_98(wt_netmon, create_menu_entry_netmon_screen);
-    
     mn_submenu_finalize2();
 }
+
+//==========================================================================================================//
 
 void create_menu_utilies_hook(void)
 {
@@ -1939,12 +2058,12 @@ void create_menu_utilies_hook(void)
     md380_create_menu_entry(8, md380_wt_programradio, MKTHUMB(md380_menu_entry_programradio), MKTHUMB(md380_menu_entry_back), 0x8a, 0, enabled);
 
 #  ifdef FW_D13_020
-    md380_create_menu_entry(11, wt_addl_func, MKTHUMB(create_menu_entry_addl_functions_screen), MKTHUMB(md380_menu_entry_back), 0x8a, 0, 1);
+    md380_create_menu_entry(11, wt_main_menu, MKTHUMB(create_main_md380tools_screen), MKTHUMB(md380_menu_entry_back), 0x8a, 0, 1);
 #  else
     if( menu_mem->numberof_menu_entries == 6 ) { // d13.020 has hidden gps entrys on this menu
-        md380_create_menu_entry(11, wt_addl_func, MKTHUMB(create_menu_entry_addl_functions_screen), MKTHUMB(md380_menu_entry_back), 0x8a, 0, 1);
+        md380_create_menu_entry(11, wt_main_menu, MKTHUMB(create_main_md380tools_screen), MKTHUMB(md380_menu_entry_back), 0x8a, 0, 1);
     } else {
-        md380_create_menu_entry(9, wt_addl_func, MKTHUMB(create_menu_entry_addl_functions_screen), MKTHUMB(md380_menu_entry_back), 0x8a, 0, 1);
+        md380_create_menu_entry(9, wt_main_menu, MKTHUMB(create_main_md380tools_screen), MKTHUMB(md380_menu_entry_back), 0x8a, 0, 1);
     }
 #  endif
 

--- a/applet/src/netmon.c
+++ b/applet/src/netmon.c
@@ -10,6 +10,7 @@
 #include "tooldfu.h"
 #include "printf.h"
 #include "string.h"
+#include "dmesg.h"
 #include "dmr.h"
 #include "gfx.h"
 #include "radiostate.h"
@@ -448,16 +449,25 @@ void netmon6_update()
 #endif
 }
 
-void findcc(){
+void findcc()
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
   con_clrscr();
   con_printf("Netmon CC Scan =============");
-  int cc;
-  c5000_spi0_readreg(0x52, &cc); 
+  int cc = 0;
+
+  c5000_spi0_readreg(0x52, dmesg_tx_buf);
+  cc = *dmesg_tx_buf;	
+ 
   if( (cc>>4) >= 0 && (cc>>4) <= 16 && (radio_status_1.m3 == 3)){
     con_printf("\nActive CC: %d", cc>>4);
   } else {
     con_printf("\nNo CC detected");
   }
+#else
+    clog_printf("No CC scan available\n");
+#endif
+
 }
 
 void netmon_update()

--- a/applet/src/netmon.c
+++ b/applet/src/netmon.c
@@ -312,12 +312,24 @@ void netmon4_update()
 
             print_time_hook(log);
 
-            if( usr_find_by_dmrid(&usr, src) == 0 ) {
-                lastheard_printf("=%d->%d %c\n", src, rst_dst, mode);
-            } else {
-                lastheard_printf("=%s->%d %c\n", usr.callsign, rst_dst, mode);
-            }
+	// loookup source ID in user database to show callsign instead of ID
+	        if( usr_find_by_dmrid(&usr, src) == 0 ) {
+			// lookup destination ID in user database for status requests etc.
+	                if( usr_find_by_dmrid(&usr, rst_dst) != 0 ) {
+	                        lastheard_printf("=%d->%s %c\n", src, usr.callsign, mode);
+	                } else  {
+	                        lastheard_printf("=%d->%d %c\n", src, rst_dst, mode);
+	                }
+	        } else {
+	            lastheard_printf("=%s->", usr.callsign);
+	                if( usr_find_by_dmrid(&usr, rst_dst) != 0 ) {
+	                        lastheard_printf("%s %c\n", usr.callsign, mode);
+	                } else  {
+	                        lastheard_printf("%d %c\n", rst_dst, mode);
+			}
+		}
         }
+
         if ( global_addl_config.userscsv > 1 && (talkerAlias.displayed != 1 && talkerAlias.length > 0) )
         {
             talkerAlias.displayed = 1;

--- a/applet/src/netmon.c
+++ b/applet/src/netmon.c
@@ -1,6 +1,6 @@
 /*
  *  netmon.c
- * 
+ *
  */
 
 #include "netmon.h"
@@ -26,8 +26,8 @@
 
 #if (CONFIG_APP_MENU)
 # include "app_menu.h"     // alternative menu, with faster text display
-# include "lcd_driver.h"   // alternative LCD driver, less QRM, faster 
-# include "irq_handlers.h" // stopwatch for periodic framebuffer updates 
+# include "lcd_driver.h"   // alternative LCD driver, less QRM, faster
+# include "irq_handlers.h" // stopwatch for periodic framebuffer updates
 #endif // CONFIG_APP_MENU ?
 
 uint8_t nm_screen = 0 ;
@@ -53,7 +53,7 @@ int progress = 0 ;
 #endif
 /* uint16_t *cntr2 = (void*)0x2001e844 ;*/
 
-#if defined(FW_D13_020) || defined(FW_S13_020)  
+#if defined(FW_D13_020) || defined(FW_S13_020)
     extern uint16_t m_cntr2 ;
 #endif
 
@@ -61,22 +61,22 @@ int progress = 0 ;
 uint8_t gui_opmode3 = 0xFF ;
 uint16_t m_cntr2 = 0x00;
 #endif
-    
+
 // mode2
 // 1 idle
 // 2 rx/tx
 // 4 post-rx/tx
 // 10 menu
 
-// mode3 
+// mode3
 // 0 = idle?
 // 3 = unprog channel
 // 5 = block dmr processing?
 
 // radio events (todo fix)
 // 0x01 = nosig
-// 0x02 = sync error? (tx only?) 
-// 0x03 = FM 
+// 0x02 = sync error? (tx only?)
+// 0x03 = FM
 // 0x04 = sync
 // 0x05 = ?
 // 0x07 = idle
@@ -88,7 +88,7 @@ uint16_t m_cntr2 = 0x00;
 uint8_t last_radio_event ;
 //
 
-// beep events 
+// beep events
 // 0x0e negative on ptt
 // 0x0f not programmed channel
 // 0x11 postive on ptt
@@ -118,7 +118,7 @@ void print_vce()
 
 void print_smeter()
 {
-#if defined(FW_D13_020) || defined(FW_S13_020)  
+#if defined(FW_D13_020) || defined(FW_S13_020)
     extern uint8_t smeter_rssi ;
     con_printf("rssi:%d\n", smeter_rssi );
 #endif
@@ -128,26 +128,26 @@ void netmon1_update()
 {
     progress++ ;
     progress %= sizeof( progress_info ) - 1 ;
-    
-    int progress2 = progress ; // sample (thread safe) 
+
+    int progress2 = progress ; // sample (thread safe)
 
     progress2 %=  sizeof( progress_info ) - 1 ;
     char c = progress_info[progress2];
-    
+
     con_clrscr();
-    
-    con_printf("%c|%02d|%2d|%2d|%4d\n", c, gui_opmode1 & 0x7F, gui_opmode2, gui_opmode3, m_cntr2 ); 
-    
+
+    con_printf("%c|%02d|%2d|%2d|%4d\n", c, gui_opmode1 & 0x7F, gui_opmode2, gui_opmode3, m_cntr2 );
+
 #if defined(FW_D13_020) || defined(FW_S13_020)
     extern uint8_t channel_num ;
-    con_printf("ch:%d ", channel_num ); 
-    
+    con_printf("ch:%d ", channel_num );
+
     con_printf("zn:%S\n",zone_name);
     con_printf("con:%S\n",contact.name);
-    
+
     extern wchar_t channel_name[] ;
-    con_printf("cn:%S\n",channel_name); 
-#endif   
+    con_printf("cn:%S\n",channel_name);
+#endif
     {
         char *str = "?" ;
         switch( last_radio_event ) {
@@ -164,7 +164,7 @@ void netmon1_update()
                 str = "Out_of_sync" ; // TS 102 361-2 clause p 5.2.1.3.2
                 break ;
             case 0x5 :
-                str = "num5 0x5" ; 
+                str = "num5 0x5" ;
                 break ;
             case 0x7 :
                 str = "RX csbk/idle" ;
@@ -194,29 +194,29 @@ void netmon1_update()
 #if defined(FW_D13_020) || defined(FW_S13_020)
     {
 //        uint8_t *p = (void*)0x2001e5f0 ; // @D13
-        con_printf("st: %2x %2x %2x %2x\n", 
-                radio_status_1.m0, radio_status_1.m1, 
+        con_printf("st: %2x %2x %2x %2x\n",
+                radio_status_1.m0, radio_status_1.m1,
                 radio_status_1.m2, radio_status_1.m3 );
     }
-#endif    
+#endif
 #ifdef FW_D13_020
     {
         // only valid when transmitting or receiving.
         uint32_t *recv = (void*)0x2001e5e4 ;
-        con_printf("%d\n", *recv); 
+        con_printf("%d\n", *recv);
     }
-#endif    
+#endif
 #ifdef FW_S13_020
     {
         // only valid when transmitting or receiving.
         uint32_t *recv = (void*)0x2001e6b4 ;                    // needs to be confirmed!
-        con_printf("%d\n", *recv); 
+        con_printf("%d\n", *recv);
     }
-#endif     
+#endif
 }
 
 void print_bcd( uint8_t bcd )
-{    
+{
     con_printf("%d%d", (bcd>>4)&0xf, bcd&0xf );
 }
 
@@ -234,14 +234,14 @@ void netmon2_update()
     con_clrscr();
 #if defined(FW_D13_020) || defined(FW_S13_020)
     channel_info_t *ci = &current_channel_info ;
-    
+
     {
         con_printf("mde:%02x prv:%02x pow:%02x\n", ci->mode, ci->priv, ci->power );
-        
+
         con_puts("rx:");
         printfreq(&ci->rxf);
         con_nl();
-        
+
         con_puts("tx:");
         printfreq(&ci->txf);
         con_nl();
@@ -255,13 +255,13 @@ void netmon2_update()
     }
 #else
     con_puts("D13 has more\n");
-#endif    
+#endif
     print_hdr();
     print_vce();
-    
+
 //    {
 //        extern uint32_t kb_handler_count ;
-//        extern uint32_t f4225_count ; 
+//        extern uint32_t f4225_count ;
 //
 //        con_printf("%d %d\n", kb_handler_count, f4225_count);
 //    }
@@ -277,17 +277,17 @@ void netmon4_update()
 {
 #if defined(FW_D13_020) || defined(FW_S13_020)
     lastheard_draw_poll();
-    lastheard_redraw();	
+    lastheard_redraw();
     int src;
     char log = 'l';
 
     if ( nm_started == 0 ) {
         lastheard_printf("Netmon 4 - Lastheard ====\n");
         nm_started = 1;                         // flag for restart of LH list
-    }   
+    }
 
     char mode = ' ' ;
-    if( (rst_voice_active != previous_call_state)  && ( rst_voice_active) )
+    if( (rst_voice_active != previous_call_state) && ( rst_voice_active) )
     {
         call_start_state = 1;
         talkerAlias.displayed = 0;
@@ -296,13 +296,13 @@ void netmon4_update()
 
     if( ( rst_voice_active ) || (lh_new == 1) ){
         if( rst_mycall ) {
-            mode = '*' ; // on my tg            
+            mode = '*' ; // on my tg
         } else {
             mode = '!' ; // on other tg
         }
         src = rst_src;
         user_t usr;
-   
+
         if( ( src != 0 ) && ( rst_flco < 4 ) && call_start_state == 1 ) {
             call_start_state = 0;
             lh_new = 0;                         // reset status for netmon4
@@ -324,8 +324,8 @@ void netmon4_update()
         }
     }
 #else
-    lastheard_printf("No lastheard available\n");    
-#endif 
+    lastheard_printf("No lastheard available\n");
+#endif
 
 }
 
@@ -333,24 +333,24 @@ void netmon5_update()
 {
 #if defined(FW_D13_020) || defined(FW_S13_020)
     slog_draw_poll();
-    slog_redraw();	
+    slog_redraw();
     int src;
     char slog = 's';
 
-    extern wchar_t channel_name[20] ;           // read current channel name from external  
+    extern wchar_t channel_name[20] ;           // read current channel name from external
     static int sl_cnt = 0 ;                     // lastheard line counter
     static int cp_cnt = 1 ;                     // lastheard channel page counter
 
     if ( nm_started5 == 0 ) {
         slog_printf("Netmon 5 LH Channel =========\n");
         nm_started5 = 1;                        // flag for restart of LH list
-        sl_cnt++;                               // reset lh counter 
+        sl_cnt++;                               // reset lh counter
     }   
 
     char mode = ' ' ;
     if( rst_voice_active ) {
         if( rst_mycall ) {
-            mode = '*' ; // on my tg            
+            mode = '*' ; // on my tg
         } else {
             mode = '<' ; // on other tg
         }
@@ -373,7 +373,7 @@ void netmon5_update()
                         sl_cnt = 0;                                             // reset sl_cnt at end of screen
                         cp_cnt++;                                               // increment lh page count
                 } else {
-                        slog_printf("cn:%S ---------------\n", curr_channel);   // show divider line when channel changes       
+                        slog_printf("cn:%S ---------------\n", curr_channel);   // show divider line when channel changes
                 }
                 wcscpy(sh_last_channel, curr_channel);
                 sl_cnt++;
@@ -404,8 +404,8 @@ void netmon5_update()
      }
     }
 #else
-    slog_printf("No lastheard available\n");    
-#endif 
+    slog_printf("No lastheard available\n");
+#endif
 
 }
 
@@ -414,9 +414,9 @@ void netmon6_update()
 {
 #if defined(FW_D13_020) || defined(FW_S13_020)
     clog_draw_poll();
-    clog_redraw();	
+    clog_redraw();
     char clog = 'c';
-    
+
     extern wchar_t channel_name[20] ;           // read current channel name from external  
     static int ch_cnt = 0 ;                     // lastheard line counter
 
@@ -424,7 +424,7 @@ void netmon6_update()
         clog_printf("Netmon 6 RX channel ========\n");
         nm_started6 = 1;                        // flag for restart of LH list
         ch_cnt = 1;                             // reset lh counter 
-    }   
+    }
 
     if( ch_new == 1 ) {
 
@@ -437,15 +437,27 @@ void netmon6_update()
 
         if (wcscmp(ch_last_channel, curr_channel) != 0)  {         // compare channel_name with last_channel from latest rx
                 print_time_hook(clog);
-                clog_printf("-%02d:%S \n", ch_cnt, curr_channel);  // show divider line when channel changes       
+                clog_printf("-%02d:%S \n", ch_cnt, curr_channel);  // show divider line when channel changes
                 wcscpy(ch_last_channel, curr_channel);
                 ch_cnt++;
           }
         ch_new = 0 ;                            // call handled, wait until new voice call status received
      }
 #else
-    clog_printf("No channellog available\n");    
-#endif 
+    clog_printf("No channellog available\n");
+#endif
+}
+
+void findcc(){
+  con_clrscr();
+  con_printf("Netmon CC Scan =============");
+  int cc;
+  c5000_spi0_readreg(0x52, &cc); 
+  if( (cc>>4) >= 0 && (cc>>4) <= 16 && (radio_status_1.m3 == 3)){
+    con_printf("\nActive CC: %d", cc>>4);
+  } else {
+    con_printf("\nNo CC detected");
+  }
 }
 
 void netmon_update()
@@ -496,7 +508,7 @@ void netmon_update()
 // and use individual printf-functions to fill them:
 //    Netmon4 -> lastheard_printf() -> char lastheard_buf[LASTHEARD_SIZE];
 //    Netmon5 -> slog_printf()      -> char slog_buf[SLOG_SIZE];
-//               slog_draw_poll() :  copies slog_buf[] to con_buf[][];  
+//               slog_draw_poll() :  copies slog_buf[] to con_buf[][];
 //    Netmon6 -> clog_printf()      -> char clog_buf[CLOG_SIZE];
 // So, with some trickery, lastheard.c and most of the netmon functions
 // don't need to be modified to show the netmon-screens in the app-menu.
@@ -527,7 +539,7 @@ static void NetMon_Draw(app_menu_t *pMenu, int netmon_screen )
         break;
      case 4 :
         lastheard_redraw(); // convince lastheard_draw_poll(?) to do something
-        netmon4_update(); // -> lastheard_draw_poll(?), 
+        netmon4_update(); // -> lastheard_draw_poll(?),
         break;
      case 5 :
         netmon4_update(); // required for what (possibly 'collects data') ?
@@ -539,6 +551,9 @@ static void NetMon_Draw(app_menu_t *pMenu, int netmon_screen )
         clog_redraw();    // set flag for netmon6_update() to do something
         netmon4_update(); // seems to "acquire" something for other screens, too.
         netmon6_update(); // netmon6_update() -> clog_draw_poll() -> con_clrscr(), ...
+        break;
+     case 0 :
+        findcc();
         break;
      default:
         con_clrscr();
@@ -556,7 +571,7 @@ static void NetMon_Draw(app_menu_t *pMenu, int netmon_screen )
    }
   if( pMenu->value_chksum != checksum )
    {  pMenu->value_chksum =  checksum;
-      pMenu->redraw = TRUE;  
+      pMenu->redraw = TRUE;
    }
 
   if( pMenu->redraw || (ReadStopwatch_ms(&stopwatch_for_update)>1000/*ms*/) )
@@ -567,7 +582,7 @@ static void NetMon_Draw(app_menu_t *pMenu, int netmon_screen )
      Menu_GetColours( SEL_FLAG_NONE, &dc.fg_color, &dc.bg_color );
 
      dc.font = LCD_OPT_FONT_8x8;
-     LCD_Printf( &dc, "\tNetmon %d\r", netmon_screen ); 
+     LCD_Printf( &dc, "\tNetmon %d\r", netmon_screen );
      dc.font = LCD_OPT_FONT_6x12;
      con_y = 0;
      while( (con_y<CONSOLE_Y_SIZE) && (dc.y<LCD_SCREEN_HEIGHT) )
@@ -582,7 +597,7 @@ static void NetMon_Draw(app_menu_t *pMenu, int netmon_screen )
         sz40[con_x] = '\0';
         dc.x = 0;
         LCD_Printf( &dc, "%s\r", sz40 ); // unlike '\n', '\r' clears the rest of the line
-      } 
+      }
      // If necessary, clear the rest of the screen (at the bottom) :
      LCD_FillRect( 0, dc.y, LCD_SCREEN_WIDTH-1, LCD_SCREEN_HEIGHT-1, dc.bg_color );
      pMenu->redraw = FALSE;    // "done" (screen has been redrawn)
@@ -594,7 +609,7 @@ static void NetMon_Draw(app_menu_t *pMenu, int netmon_screen )
 
 //---------------------------------------------------------------------------
 int am_cbk_NetMon(app_menu_t *pMenu, menu_item_t *pItem, int event, int param )
-  // Callback function, invoked from the "app menu" framework 
+  // Callback function, invoked from the "app menu" framework
   // to paint ONE of the SIX (?) netmon screens into the LCD framebuffer.
 {
   switch( event ) // what happened, why did the menu framework call us ?
@@ -607,7 +622,7 @@ int am_cbk_NetMon(app_menu_t *pMenu, menu_item_t *pItem, int event, int param )
         if( pMenu->visible == APPMENU_USERSCREEN_VISIBLE ) // only if HexMon already 'occupied' the screen !
          { // To minimize QRM from the display cable, only redraw the screen
            // if the content of the 'console' has been modified.
-           // But to calculate a CRC for the console screen, 
+           // But to calculate a CRC for the console screen,
            // the netmon-screen-specific buffer must be copied (printed)
            // into con_buf[][] first. Then, let NetMon_Draw() decide
            // if it's really necessary to 'send pixels over the cable'.
@@ -617,7 +632,7 @@ int am_cbk_NetMon(app_menu_t *pMenu, menu_item_t *pItem, int event, int param )
            return AM_RESULT_OCCUPY_SCREEN; // keep the screen 'occupied'
          }
         break;
-     case APPMENU_EVT_KEY : // own keyboard control only if the screen is owned by HexMon : 
+     case APPMENU_EVT_KEY : // own keyboard control only if the screen is owned by HexMon :
         if( pMenu->visible == APPMENU_USERSCREEN_VISIBLE ) // only if HexMon already 'occupied' the screen !
          { switch( (char)param ) // here: message parameter = keyboard code (ASCII)
             {

--- a/applet/src/netmon.c
+++ b/applet/src/netmon.c
@@ -471,19 +471,16 @@ void netmon_update()
             netmon3_update();
             return ;
         case 4 :
-	    //lastheard_redraw();	
             netmon6_update();
             netmon5_update();
             netmon4_update();
             return ;
         case 5 :
-	    //slog_redraw();	
             netmon4_update();
             netmon6_update();
             netmon5_update();
             return ;
         case 6 :
-	    //clog_redraw();	
             netmon4_update();
             netmon5_update();
             netmon6_update();

--- a/applet/src/rtc_timer.c
+++ b/applet/src/rtc_timer.c
@@ -19,6 +19,7 @@
 #include "usersdb.h"
 #include "display.h"
 #include "dmr.h"
+#include "dmesg.h"
 #include "console.h"
 #include "util.h"
 #include "debug.h"
@@ -27,7 +28,7 @@
 #include "irq_handlers.h"
 #include "narrator.h"
 #include "app_menu.h"
-
+#include "system_hrc5000.h"
  
 //static int flag=0;
 
@@ -276,7 +277,9 @@ void trace_gui_opmode1()
         return ;
     }
     if( old != new ) {
+#if defined CONFIG_KEYBTRACE
         PRINT( "mode1: %d -> %d (%d)\n", old, new, upd );
+#endif
         old = new ;
     }
 }
@@ -286,7 +289,9 @@ void trace_gui_opmode2()
     static int old = -1 ;
     int new = gui_opmode2 ;
     if( old != new ) {
+#if defined CONFIG_KEYBTRACE
         PRINT( "mode2: %d -> %d\n", old, new );
+#endif
         LOGG( "mode2: %d -> %d\n", old, new );
         old = new ;
 #      if( CONFIG_MORSE_OUTPUT ) 
@@ -315,7 +320,8 @@ void trace_gui_opmode3()
 }
 #endif
 
-static char fCntAGC = 0;
+static int rtc_hook_timer = 0;
+
 void f_4225_hook()
 {
     
@@ -327,6 +333,7 @@ void f_4225_hook()
     
     static int old = -1 ;
     int new = gui_opmode1 & 0x7F ;
+
     if( old != new ) {
         if( gui_opmode2 == OPM2_MENU ) {
             // menu is showing.
@@ -340,25 +347,34 @@ void f_4225_hook()
             old = new ;
         }
     }
-    
+
     if ( global_addl_config.micbargraph == 1 ) {
         if( !is_netmon_visible() ) {
             draw_micbargraph();
         }
     }
-	fCntAGC++;
+    rtc_hook_timer++;
 	
-	if ( global_addl_config.mic_gain > 0 && fCntAGC==30) {
-		if(global_addl_config.mic_gain==1){
-			c5000_spi0_writereg( 0x0F, 0xD8);
-		}
-		else if(global_addl_config.mic_gain==2){
-			c5000_spi0_writereg( 0x0F, 0xE8);
-		}
+    if ( global_addl_config.mic_gain > 0 && rtc_hook_timer==30) {
+	if(global_addl_config.mic_gain==1){
+		c5000_spi0_writereg( 0x0F, 0xD8);
 	}
-	if(fCntAGC==200)
-		fCntAGC=0;
-    
+	else if(global_addl_config.mic_gain==2){
+		c5000_spi0_writereg( 0x0F, 0xE8);
+	}
+    }
+
+    if ( rtc_hook_timer%150==0 && !IS_PTT_PRESSED) {
+	hrc5000_check();		// check FM registers (BPF, compression, pre-emphasis, bandwith)
+    }
+	
+    if ( rtc_hook_timer%111==0 && !IS_PTT_PRESSED) {
+	hrc5000_dev_set();		// set FM deviation level (default=0, user=1-5)
+    }
+
+    if(rtc_hook_timer >= 200)
+	rtc_hook_timer=0;
+
     netmon_update();
 
 #  if( CONFIG_MORSE_OUTPUT ) 

--- a/applet/src/rtc_timer.c
+++ b/applet/src/rtc_timer.c
@@ -315,6 +315,7 @@ void trace_gui_opmode3()
 }
 #endif
 
+static char fCntAGC = 0;
 void f_4225_hook()
 {
     
@@ -345,6 +346,18 @@ void f_4225_hook()
             draw_micbargraph();
         }
     }
+	fCntAGC++;
+	
+	if ( global_addl_config.mic_gain > 0 && fCntAGC==30) {
+		if(global_addl_config.mic_gain==1){
+			c5000_spi0_writereg( 0x0F, 0xD8);
+		}
+		else if(global_addl_config.mic_gain==2){
+			c5000_spi0_writereg( 0x0F, 0xE8);
+		}
+	}
+	if(fCntAGC==200)
+		fCntAGC=0;
     
     netmon_update();
 

--- a/applet/src/system_hrc5000.c
+++ b/applet/src/system_hrc5000.c
@@ -1,0 +1,378 @@
+/**
+  ******************************************************************************
+  * @file    system_hrc5000.c
+  * @author  Meinhard F. Guenther, DL2MF
+  * @version V1.0.0 - initial release
+  * @date    04-June-2017
+  * @brief   HR_C5000 is Hong Rui independent research and development in line 
+  *          with ETSI TS102 361 (DMR) standard digital intercom dedicated chip. 
+  *          Chip using 4FSK modulation and demodulation technology, 
+  *          12.5K channel using 2-slot TDMA communication mechanism to achieve
+  *          2 Way digital voice and data communication transmission.
+  *             
+  * 1.  This file provides access to different register functions:
+  *      - hrc5000_fm_set():   Setup single register functions (see table below) to
+  *			       give user access to modified FM settings.
+  *                            The corresponding bits are set by bitmask functions.
+  *
+  *      - hrc5000_fm_reset(): Restore factory default settings to FM setup register
+  *                            and save changed setup config to radio configuration.
+  *
+  * 2. This file configures the HR_C5000 baseband chip as follows:
+  *=============================================================================
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  | Type | Address |R/W| Name                 | Def.|     |                    |
+  |      |         |   |                      | Val.| Bit | Description        | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  | Hard-|  0x0F   |R/W| ADLinVol             |0xB8 |  7  |11111:12dB no mod|  | 
+  | ware |         |   |                      |     |  6  |11110:10db no mod|  | 
+  | Cfg. |         |   |                      |     |  5  |11101: 9dB          | 
+  |      |         |   |                      |     |  4  |...                 | 
+  |      |         |   |                      |     |  3  |00000:-34.5dB       | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  | Hard-|  0x0F   |R/W| MicVol               |     |  2  |00= 0dB             | 
+  | ware |         |   |                      |     |  1  |01= 6db             | 
+  | Cfg. |         |   |                      |     |     |10=12db             | 
+  |-cont-|         |   |                      |     |     |11=20db             | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  |  FM  |  0x34   |R/W| FMBpfOn              |     |  7  |0=Bpfilt off 1=on   | 
+  |  set |         |   | FMCompressorOn       |0xF0 |  6  |0=Comprs off 1=on   | 
+  |      |         |   | FMPreEmphasisOn      |     |  5  |0=PreEmp off 1=on   | 
+  |      |         |   | FMBandWidth          |     |  4  |0=12.5kHz 1=25kHz   | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  |  FM  |  0x35   |R/W| FM Deviation         |0xA0 |  7  |A0...F0 mod.level   | 
+  |devia.|         |   |                      |     |  6  |        settings    | 
+  |      |         |   |                      |     |  5  |                    | 
+  |      |         |   |                      |     |  4  |                    | 
+  |      |         |   |                      |     |0...3|reserved            | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  |      |         |   |                      |     |     |                    | 
+  +------+---------+---+----------------------+-----+-----+--------------------+
+  *============================================================================*
+  ****************************************************************************** 
+  * @attention
+  *
+  * THE PRESENT SOFTWARE IS FOR EXPERIMENTAL ONLY AIMS AT PROVIDING CUSTOMERS
+  * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+  * TIME. AS A RESULT, THE AUTHOR SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
+  * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+  * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+  * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+  ******************************************************************************
+  */
+
+#define DEBUG
+
+#include "config.h"
+
+#include "md380.h"
+#include "version.h"
+#include "printf.h"
+#include "string.h"
+#include "addl_config.h"
+#include "ambe.h"
+#include "dmr.h"
+#include "dmesg.h"
+#include "console.h"
+#include "util.h"
+#include "debug.h"
+#include "netmon.h"
+#include "syslog.h"
+#include "irq_handlers.h"
+#include "system_hrc5000.h"
+
+
+int fm_reg_val = 0x00;		// register value of HRC_5000 FM settings 
+int fm_reg_set = 0x00;		// bitmask with last settings of register
+
+int fm_dev_set = 0x00;		// bitmask with last settings of deviation
+int fm_dev_val = 0x00;		// register value of HRC_5000 FM deviation
+
+int state;
+
+char *hrc5000_register; //=(char*) DMESG_START;
+char hrc5000_reg[HRC5000_BUFFER_SIZE];
+
+void hrc5000_check(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+  /*----------------------------------------------------------------
+
+    HRC_5000 - sanity check
+    -----------------------------------------------------------------	
+    0x34 - FM bandpass filter, compressor, preemphasis, bandwidth
+    0x35 - FM deviation
+  ------------------------------------------------------------------*/
+
+	hrc5000_fm_read();				// read fm_reg_val before register handling
+
+	if (fm_reg_val != global_addl_config.fm_mode){
+		PRINT("fm_reg was last: %02x now read: %02x\n", global_addl_config.fm_mode, fm_reg_val);
+
+		hrc5000_fm_set();			// set fm_reg_val
+//		hrc5000_fm_read();			// read fm_reg_val before register handling
+
+		if(global_addl_config.devmode_level == 3)	// developer mode 3 verbose register log to usb console
+			PRINT("FM_REG set >> %02x <-r/w-> %02x\n", *hrc5000_reg, fm_reg_set );
+	} /*else {
+		c5000_spi0_writereg(FM_SET_REGISTER, fm_reg_set);	// rewrite register value to HRC5000
+		PRINT("FM_REG rpt >> %02x <-r/w-> %02x\n", *hrc5000_reg, fm_reg_set );
+	}
+*/
+
+
+#else
+#endif		// #if defined D13.020 || S13.020
+}
+
+void hrc5000_fm_set(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+  /*----------------------------------------------------------------
+
+    HRC_5000 - FM setup register 0x34 - FM Settings
+    -----------------------------------------------
+    Bit 7 - 0x80	fm_bpf;		// 0=off, 1=on
+    Bit 6 - 0x40	fm_comp;	// 0=off, 1=on
+    Bit 5 - 0x20	fm_preemp;	// 0=off, 1=on
+    Bit 4 - 0x10	fm_bw;		// 0=12.5kHz, 1=25kHz
+
+  ------------------------------------------------------------------*/
+
+	if(global_addl_config.fm_bpf == 0){
+//		PRINT("fm_reg clr-1: %02x (before)\n", fm_reg_val);
+		fm_reg_val &= ~(1 << FM_BPF_MASK);
+		PRINT("fm_reg clr-1: %02x (mask:%02x)\n", fm_reg_val, FM_BPF_MASK);
+	} else if (global_addl_config.fm_bpf == 1){
+//		PRINT("fm_reg set-1: %02x (before)\n", fm_reg_val);
+		fm_reg_val |= (1 << FM_BPF_MASK);
+		PRINT("fm_reg set-1: %02x (mask:%02x)\n", fm_reg_val, FM_BPF_MASK);
+	}
+
+	if(global_addl_config.fm_comp == 0){
+//		PRINT("fm_reg clr-2: %02x (before)\n", fm_reg_val);
+		fm_reg_val &= ~(1 << FM_COMP_MASK);
+		PRINT("fm_reg clr-2: %02x (mask:%02x)\n", fm_reg_val, FM_COMP_MASK);
+	} else if (global_addl_config.fm_comp == 1){
+//		PRINT("fm_reg set-2: %02x (before)\n", fm_reg_val);
+		fm_reg_val |= (1 << FM_COMP_MASK);
+		PRINT("fm_reg set-2: %02x (mask:%02x)\n", fm_reg_val, FM_COMP_MASK);
+	}
+
+	if(global_addl_config.fm_preemp == 0){
+//		PRINT("fm_reg clr-3: %02x (before)\n", fm_reg_val);
+		fm_reg_val &= ~(1 << FM_PREEMP_MASK);
+		fm_reg_val = 0x1c;
+		PRINT("fm_reg clr-3: %02x (mask:%02x)\n", fm_reg_val, FM_PREEMP_MASK);
+	} else if (global_addl_config.fm_preemp == 1){
+//		PRINT("fm_reg set-3: %02x (before)\n", fm_reg_val);
+		fm_reg_val |= (1 << FM_PREEMP_MASK);
+		PRINT("fm_reg set-3: %02x (mask:%02x)\n", fm_reg_val, FM_PREEMP_MASK);
+	}
+
+	if(global_addl_config.fm_bw == 0){
+//		PRINT("fm_reg clr-4: %02x (before)\n", fm_reg_val);
+		fm_reg_val &= ~(1 << FM_BANDW_MASK);
+		PRINT("fm_reg clr-4: %02x (mask:%02x)\n", fm_reg_val, FM_BANDW_MASK);
+	} else if (global_addl_config.fm_bw == 1){
+//		PRINT("fm_reg set-4: %02x (before)\n", fm_reg_val);
+		fm_reg_val |= (1 << FM_BANDW_MASK);
+		PRINT("fm_reg set-4: %02x (mask:%02x)\n", fm_reg_val, FM_BANDW_MASK);
+	}
+	state=OS_ENTER_CRITICAL();
+	c5000_spi0_writereg(FM_SET_REGISTER, fm_reg_val);	// set new register value to HRC5000
+	OS_EXIT_CRITICAL(state);
+	fm_reg_set = fm_reg_val;				// store new register bitmask
+
+	global_addl_config.fm_mode = fm_reg_set;		// write to SPI flash
+	cfg_save();
+
+/*----------------------------------------------------------------*/
+  
+#else
+#endif		// #if defined D13.020 || S13.020
+}
+
+void hrc5000_dev_set(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+  /*----------------------------------------------------------------
+
+    HRC_5000 - FM deviation setup register 0x35 - FM Settings
+    ---------------------------------------------------------
+    Bit 7-4 - 0xA0-0xF0	fm_dev;		// default 0xA0
+
+  ------------------------------------------------------------------*/
+
+	hrc5000_dev_read();		// read fm_reg_val before register handling
+
+	if (fm_dev_val != fm_dev_set){
+
+		if(global_addl_config.devmode_level > 2)		// developer mode 3 verbose register log to usb console
+			PRINT("FM_DEV was last: %02x now read: %02x\n", fm_dev_set, fm_dev_val);
+
+		if(global_addl_config.devmode_level > 2)		// developer mode 3 verbose register log to usb console
+			PRINT("FM_DEV bitshift before: %02x\n", fm_dev_val);
+		fm_dev_val = fm_dev_val<<4;
+		fm_dev_val = fm_dev_val>>4;
+
+		if(global_addl_config.devmode_level > 1)		// developer mode 2 register log to usb console
+			PRINT("FM_DEV bitshift after : %02x\n", fm_dev_val);
+
+  		switch ( global_addl_config.fm_dev ) {
+    		case 0 :
+			fm_dev_val |= FM_DEV0;
+			break;
+    		case 1 :
+			fm_dev_val |= FM_DEV1;
+			break;
+    		case 2 :
+			fm_dev_val |= FM_DEV2;
+			break;
+    		case 3 :
+			fm_dev_val = FM_DEV_DEFAULT;			// no logical operation, set default!!
+			break;
+    		case 4 :
+			fm_dev_val |= FM_DEV4;
+			break;
+    		case 5 :
+			fm_dev_val |= FM_DEV5;
+			break;
+    		case 6 :
+			fm_dev_val |= FM_DEV6;
+			break;
+		default:
+			return;
+		}
+
+		state=OS_ENTER_CRITICAL();
+		c5000_spi0_writereg(FM_DEV_REGISTER, fm_dev_val);	// set new register value to HRC5000
+		OS_EXIT_CRITICAL(state);
+		fm_dev_set = fm_dev_val;
+
+		state=OS_ENTER_CRITICAL();
+		c5000_spi0_readreg(FM_DEV_REGISTER, hrc5000_reg);
+		OS_EXIT_CRITICAL(state);
+		fm_dev_val = *hrc5000_reg;
+
+		if (IRQ_dwSysTickCounter < 3500)			// log to screen after load start cfg
+		    	LOGB("t=%d: FM_DEV load=%02X\n", (int)IRQ_dwSysTickCounter, (int)fm_dev_val );
+		if(global_addl_config.devmode_level > 1)		// developer mode 2 register log to usb console
+			PRINT("FM_DEV set >> lvl:%d reg:%02x <-r/w-> %02x\n", global_addl_config.fm_dev, *hrc5000_reg, fm_dev_set );
+	} else {
+		state=OS_ENTER_CRITICAL();
+		c5000_spi0_writereg(FM_DEV_REGISTER, fm_dev_set);	// rewrite register value to HRC5000
+		OS_EXIT_CRITICAL(state);
+		if(global_addl_config.devmode_level == 3)		// developer mode 3 verbose register log to usb console
+			PRINT("FM_DEV rpt >> lvl:%d reg:%02x <-r/w-> %02x\n", global_addl_config.fm_dev, *hrc5000_reg, fm_dev_val );
+	}
+
+/*----------------------------------------------------------------*/
+  
+#else
+#endif		// #if defined D13.020 || S13.020
+}
+
+
+/*----------------------------------------------------------------*/
+void hrc5000_fm_reset(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+
+/* -- some debug code, can be removed later
+    c5000_spi0_readreg(FM_SET_REGISTER, hrc5000_reg);
+    fm_reg_val = *hrc5000_reg;
+    LOGB("t=%d: fm_reg before=%02X\n", (int)IRQ_dwSysTickCounter, (int)hrc5000_reg[0] );
+*/
+
+/* -- Reset FM registers to default --------------------------------*/
+    state=OS_ENTER_CRITICAL();
+    c5000_spi0_writereg(FM_SET_REGISTER, FM_DEFAULT);		
+    c5000_spi0_readreg(FM_SET_REGISTER, hrc5000_reg);
+    OS_EXIT_CRITICAL(state);
+
+    if(global_addl_config.devmode_level > 0)		// developer mode != 0 register log to usb console    
+    {
+	PRINT("fm_reset -> %02x\n", *hrc5000_reg);
+	LOGB("t=%04x: fm_reset=%02X\n", (int)IRQ_dwSysTickCounter, (int)hrc5000_reg[0] );
+    }
+
+/* -- Reset FM deviation to default -------------------------------*/
+//    c5000_spi0_writereg(FM_DEV_REGISTER, 0x28);	// read from register @first try
+    state=OS_ENTER_CRITICAL();
+    c5000_spi0_writereg(FM_DEV_REGISTER, FM_DEV_DEFAULT);
+    c5000_spi0_readreg(FM_DEV_REGISTER, hrc5000_reg);
+    OS_EXIT_CRITICAL(state);
+
+    if(global_addl_config.devmode_level > 0)		// developer mode != 0 register log to usb console    
+    {
+	PRINT("fm_devreset -> %02x\n", *hrc5000_reg);
+	LOGB("t=%04x: FM_DEVRST=%02X\n", (int)IRQ_dwSysTickCounter, (int)hrc5000_reg[0] );
+    }
+
+#else
+#endif		// #if defined D13.020 || S13.020
+}
+
+/*----------------------------------------------------------------*/
+void hrc5000_fm_read(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+    state=OS_ENTER_CRITICAL();
+    c5000_spi0_readreg(FM_SET_REGISTER, hrc5000_reg);
+    OS_EXIT_CRITICAL(state);
+
+    fm_reg_val = *hrc5000_reg;
+    if (IRQ_dwSysTickCounter < 5000)	// screenlog if load during start cfg
+    	LOGB("t=%d: FM_REG load=%02X\n", (int)IRQ_dwSysTickCounter, (int)fm_reg_val );
+
+#else
+#endif		// #if defined D13.020 || S13.020
+}
+
+/*----------------------------------------------------------------*/
+void hrc5000_dev_read(void)
+{
+#if defined(FW_D13_020) || defined(FW_S13_020)
+    state=OS_ENTER_CRITICAL();
+    c5000_spi0_readreg(FM_DEV_REGISTER, hrc5000_reg);
+    OS_EXIT_CRITICAL(state);
+
+    fm_dev_val = *hrc5000_reg;
+#else
+#endif		// #if defined D13.020 || S13.020
+}
+
+
+/*----------------------------------------------------------------*/
+/* This initializes the putc call.				  */
+/*----------------------------------------------------------------*/
+void hrc5000_buffer_init(void)
+{
+  //Initialize or wipe out the old read buffer content.
+  for(int i=0;i<HRC5000_BUFFER_SIZE;i++)
+    hrc5000_reg[i]=0;
+}
+
+/*----------------------------------------------------------------*/
+/* This flushes the HRC5000 register message buffer.		  */
+/*----------------------------------------------------------------*/
+void hrc5000_buffer_flush(void)
+{
+  hrc5000_buffer_init();
+}
+
+
+/****************************************************************END OF FILE****/
+

--- a/applet/src/system_hrc5000.h
+++ b/applet/src/system_hrc5000.h
@@ -1,0 +1,55 @@
+/*
+ *  system_hrc5000.h
+ * 
+ */
+
+#ifndef SYSTEM_HRC5000_H
+#define SYSTEM_HRC5000_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MIC_GAIN_REGISTER	0x0F
+#define FM_SET_REGISTER  	0x34
+#define FM_DEV_REGISTER		0x35
+
+#define FM_BPF_MASK	  	0x7
+#define FM_COMP_MASK	  	0x6
+#define FM_PREEMP_MASK	  	0x5
+#define FM_BANDW_MASK	  	0x4
+#define FM_DEFAULT	  	0xF0
+
+#define FM_DEV0			0x00	// level -3
+#define FM_DEV1			0x10	// level -2
+#define FM_DEV2			0x20	// level -1
+#define FM_DEV3			0x28	// default
+#define FM_DEV4			0x40	// level +1
+#define FM_DEV5			0x60	// level +2
+#define FM_DEV6			0x80	// level +3
+#define FM_DEV_DEFAULT		0x28
+
+#define HRC5000_BUFFER_SIZE 	16
+
+extern char hrc5000_reg[];
+extern char *hrc5000_register;
+
+#if defined(FW_D13_020) || defined(FW_S13_020)
+void hrc5000_check(void);
+void hrc5000_fm_set(void);
+void hrc5000_fm_read(void);
+void hrc5000_fm_reset(void);
+void hrc5000_dev_set(void);
+void hrc5000_dev_read(void);
+#endif
+
+void hrc5000_buffer_init(void);
+void hrc5000_buffer_flush(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_HRC5000_H */

--- a/applet/src/system_hrc5000.h
+++ b/applet/src/system_hrc5000.h
@@ -36,14 +36,12 @@ extern "C" {
 extern char hrc5000_reg[];
 extern char *hrc5000_register;
 
-#if defined(FW_D13_020) || defined(FW_S13_020)
 void hrc5000_check(void);
 void hrc5000_fm_set(void);
 void hrc5000_fm_read(void);
 void hrc5000_fm_reset(void);
 void hrc5000_dev_set(void);
 void hrc5000_dev_read(void);
-#endif
 
 void hrc5000_buffer_init(void);
 void hrc5000_buffer_flush(void);

--- a/patches/s13.020/patch.py
+++ b/patches/s13.020/patch.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
 
     # Fix some bad grammar
     patcher.setwstring(0x080f9a94,
-                       "No Fix")
+                       "No SatFix")
 
     # Change the manufacturer string. *Never Worked...*
     #    patcher.setstring(0x080f9588,


### PR DESCRIPTION
The new module system_hrc5000.c gives access to several analog FM features of the radio chipset. The user can set FM bandpass filter, compressor, preemphasis, bandwidth 12.5/25.0 kHz and deviation. Due to these experimental features, they must be enabled in the new submenu [5] DevMode Level of the developer menu. 
Another addition is concerning the keyb scroll feature, this now can be selected disabled/fast/slow in Keyb setup.
All modifications and new features have been tested on different radios from Tytera and Retevis, the feedback of all beta tester was 100% issue free. 