### PR TITLE
New build requirements added - updating default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,9 +6,11 @@ with import <nixpkgs> {}; {
       gcc-arm-embedded
       gnumake
       libusb1
+      perl
       python27
       python27Packages.pyusb
       unzip
+      which
     ];
     LD_LIBRARY_PATH="${libusb1.out}/lib";
   };


### PR DESCRIPTION
Updating default.nix file for https://nixos.org/nix
`shasum` is required (perl) and `which` is called