### PR TITLE
Fixed the calcbl offset.  Close #797.

### DIFF
--- a/applet/merge_d02.032.py
+++ b/applet/merge_d02.032.py
@@ -132,7 +132,7 @@ class Merger(object):
         # print("offset=%08x" % offset)
         offset -= 4  # PC points to the next ins.
         offset = (offset >> 1)  # LSBit is ignored.
-        hi = 0xF000 | ((offset & 0xfff800) >> 11)  # Hi address setter, but at lower adr.
+        hi = 0xF000 | ((offset & 0x3ff800) >> 11)  # Hi address setter, but at lower adr.
         lo = 0xF800 | (offset & 0x7ff)  # Low adr setter goes next.
         # print("%04x %04x" % (hi, lo))
         word = ((lo << 16) | hi)

--- a/applet/merge_d13.020.py
+++ b/applet/merge_d13.020.py
@@ -150,7 +150,7 @@ class Merger(object):
         # print("offset=%08x" % offset)
         offset -= 4  # PC points to the next ins.
         offset = (offset >> 1)  # LSBit is ignored.
-        hi = 0xF000 | ((offset & 0xfff800) >> 11)  # Hi address setter, but at lower adr.
+        hi = 0xF000 | ((offset & 0x3ff800) >> 11)  # Hi address setter, but at lower adr.
         lo = 0xF800 | (offset & 0x7ff)  # Low adr setter goes next.
         # print("%04x %04x" % (hi, lo))
         word = ((lo << 16) | hi)

--- a/applet/merge_s13.020.py
+++ b/applet/merge_s13.020.py
@@ -156,7 +156,7 @@ class Merger(object):
         # print("offset=%08x" % offset)
         offset -= 4  # PC points to the next ins.
         offset = (offset >> 1)  # LSBit is ignored.
-        hi = 0xF000 | ((offset & 0xfff800) >> 11)  # Hi address setter, but at lower adr.
+        hi = 0xF000 | ((offset & 0x3ff800) >> 11)  # Hi address setter, but at lower adr.
         lo = 0xF800 | (offset & 0x7ff)  # Low adr setter goes next.
         # print("%04x %04x" % (hi, lo))
         word = ((lo << 16) | hi)


### PR DESCRIPTION
This fixes the calcbl offsets in the `merge_*.py` scripts.  Please test lots of features before merging, as it causes function calls which were previously ignored to be properly hooked.

(This might also fix other bugs.  Who knows?)