### PR TITLE
Fix active item in promisc-, bargraph- and rogerbeep-menu

### DIFF
--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -1135,7 +1135,7 @@ void create_menu_entry_promtg_screen(void)
 {
     mn_submenu_init(wt_promtg);
 
-    if( global_addl_config.promtg == 1 ) {
+    if( global_addl_config.promtg == 0 ) {
         md380_menu_entry_selected = 0;
     } else {
         md380_menu_entry_selected = 1;
@@ -1151,7 +1151,7 @@ void create_menu_entry_micbargraph_screen(void)
 {
     mn_submenu_init(wt_micbargraph);
 
-    if( global_addl_config.micbargraph == 1 ) {
+    if( global_addl_config.micbargraph == 0 ) {
         md380_menu_entry_selected = 0;
     } else {
         md380_menu_entry_selected = 1;
@@ -1167,7 +1167,7 @@ void create_menu_entry_rbeep_screen(void)
 {
     mn_submenu_init(wt_rbeep);
 
-    if( global_addl_config.rbeep == 1 ) {
+    if( global_addl_config.rbeep == 0 ) {
         md380_menu_entry_selected = 0;
     } else {
         md380_menu_entry_selected = 1;


### PR DESCRIPTION
The menu currently shows the inverse of the current state
as selected for promiscuous-mode, mic bargraph and roger beep.
Change this so the current state is shown as selected.