### PR TITLE
backlight timer fixes

### DIFF
--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -90,7 +90,7 @@ const static wchar_t wt_no_w25q128[]        = L"No W25Q128";
 const static wchar_t wt_micbargraph[]       = L"Mic bargraph";
 
 const static wchar_t wt_backlight[]         = L"Backlight Tmr";
-const static wchar_t wt_blunchanged[]       = L"Unchanged";
+const static wchar_t wt_blalways[]          = L"Always";
 const static wchar_t wt_bl5[]               = L"5 sec";
 const static wchar_t wt_bl10[]              = L"10 sec";
 const static wchar_t wt_bl15[]              = L"15 sec";
@@ -1351,8 +1351,9 @@ void mn_backlight_set(int sec5, const wchar_t *label)
     rc_write_radio_config_to_flash();    
 }
 
-void mn_backlight_unchanged()
+void mn_backlight_always()
 {
+    mn_backlight_set(0,wt_blalways);     
 }
 
 
@@ -1392,9 +1393,9 @@ void mn_backlight(void)  // menu for the backlight-TIME (longer than Tytera's, b
        case 3 /* times 5sec */ : md380_menu_entry_selected = 3; break;
        case 6 /* times 5sec */ : md380_menu_entry_selected = 4; break;
        case 12/* times 5sec */ : md380_menu_entry_selected = 5; break;
-       default/* unchanged  */ : md380_menu_entry_selected = 0; break;
+       default/* always  */    : md380_menu_entry_selected = 0; break;
      }
-    mn_submenu_add(wt_blunchanged, mn_backlight_unchanged);
+    mn_submenu_add(wt_blalways, mn_backlight_always);
     mn_submenu_add(wt_bl5,  mn_backlight_5sec );
 
     mn_submenu_add(wt_bl10, mn_backlight_10sec);

--- a/applet/src/menu.c
+++ b/applet/src/menu.c
@@ -92,6 +92,8 @@ const static wchar_t wt_micbargraph[]       = L"Mic bargraph";
 const static wchar_t wt_backlight[]         = L"Backlight Tmr";
 const static wchar_t wt_blunchanged[]       = L"Unchanged";
 const static wchar_t wt_bl5[]               = L"5 sec";
+const static wchar_t wt_bl10[]              = L"10 sec";
+const static wchar_t wt_bl15[]              = L"15 sec";
 const static wchar_t wt_bl30[]              = L"30 sec";
 const static wchar_t wt_bl60[]              = L"60 sec";
 
@@ -1359,6 +1361,16 @@ void mn_backlight_5sec()
     mn_backlight_set(1,wt_bl5);     
 }
 
+void mn_backlight_10sec()
+{
+    mn_backlight_set(2,wt_bl10);     
+}
+
+void mn_backlight_15sec()
+{
+    mn_backlight_set(3,wt_bl15);     
+}
+
 void mn_backlight_30sec()
 {
     mn_backlight_set(6,wt_bl30);     
@@ -1376,13 +1388,17 @@ void mn_backlight(void)  // menu for the backlight-TIME (longer than Tytera's, b
     switch( md380_radio_config.backlight_time ) // inspired by stargo0's fix #674 
      { // (fixes the selection of the current backlight-time in the menu)
        case 1 /* times 5sec */ : md380_menu_entry_selected = 1; break;
-       case 6 /* times 5sec */ : md380_menu_entry_selected = 2; break;
-       case 12/* times 5sec */ : md380_menu_entry_selected = 3; break;
+       case 2 /* times 5sec */ : md380_menu_entry_selected = 2; break;
+       case 3 /* times 5sec */ : md380_menu_entry_selected = 3; break;
+       case 6 /* times 5sec */ : md380_menu_entry_selected = 4; break;
+       case 12/* times 5sec */ : md380_menu_entry_selected = 5; break;
        default/* unchanged  */ : md380_menu_entry_selected = 0; break;
      }
     mn_submenu_add(wt_blunchanged, mn_backlight_unchanged);
     mn_submenu_add(wt_bl5,  mn_backlight_5sec );
 
+    mn_submenu_add(wt_bl10, mn_backlight_10sec);
+    mn_submenu_add(wt_bl15, mn_backlight_15sec);
     mn_submenu_add(wt_bl30, mn_backlight_30sec);
     mn_submenu_add(wt_bl60, mn_backlight_60sec);
 


### PR DESCRIPTION
in both official and G6AMU CPE available options for backlight timer are always/5/10/15 sec. 

when uploading an rdt codeplug with timer set to 10/15 sec, backlight timer never fired (as it's in fact set to always, but shown as "unchanged" in backlight timer menu)

1st commit adds 10/15 sec timer that fixed the above mentioned issue
2nd commit replaces "unchanged" entry in backlight timer menu with "always", as IMO "unchanged" makes no sense, 
