### PR TITLE
Switch first 3 zones on [1][2][3] buttons

### DIFF
--- a/applet/config.h
+++ b/applet/config.h
@@ -42,3 +42,7 @@
 //#define AMBEUNCORRECTEDPRINT
 
 //#define I2CPRINT
+
+//Turn on switch first 3 zones by [1][2][3] keys (in modern keyboard layout) feature
+//if sms rpt/gps shortcuts are off. Feature by UR6LKW.
+#define ZONE123SWITCH 1

--- a/applet/src/keyb.c
+++ b/applet/src/keyb.c
@@ -152,6 +152,10 @@ void handle_hotkey( int keycode )
 	} else if ( (keycode) == (kc_sms_test) ) {
 		if (global_addl_config.sms_rpt != 0) {          
 			sms_rpt();
+		} else {
+#if (ZONE123SWITCH)	//optional quick zone switch feature, see config.h
+			ZoneList_SetZoneByIndex(0);
+#endif
 		}
 
 	} else if ( (keycode) == (kc_talkgroup) ) {
@@ -159,7 +163,11 @@ void handle_hotkey( int keycode )
 			sms_wx();
 		}
 		else {
+#if (ZONE123SWITCH)	//optional quick zone switch feature, see config.h
+			ZoneList_SetZoneByIndex(1);
+#else
 			create_menu_entry_set_tg_screen();
+#endif
 		}
 
 	} else if ( (keycode) == (kc_copy_contact) ) {
@@ -167,7 +175,11 @@ void handle_hotkey( int keycode )
 			sms_gps();
 		}
 		else {
+#if (ZONE123SWITCH)	//optional quick zone switch feature, see config.h
+			ZoneList_SetZoneByIndex(2);
+#else
  			copy_dst_to_contact();
+#endif
 		}
 
 	} else if ( (keycode) == (kc_netmon1) ) {


### PR DESCRIPTION
If sms rpt/gps functions are turned off, [1][2][3] buttons (in modern keyboard layout) can be used to quickly switch first 3 zones. Tested on my TYT MD-380.