### PR TITLE
Pull user data from dmr-marc static url

### DIFF
--- a/db/Makefile
+++ b/db/Makefile
@@ -32,7 +32,7 @@ dmrmarc2.tmp: dmrmarc.tmp
 	awk -F, -f insert_nick.awk <$< >$@
 	
 dmrmarc.tmp:
-	python2 get_dmrmarc_json.py >$@ 2>get_dmrmarc.errors
+	timeout 120 wget --no-check-certificate --wait=3 'https://dmr-marc.net/static/users.csv' -O $@
 
 reflector.tmp:
 	curl $(CURL_FLAGS) 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@


### PR DESCRIPTION
dmr-marc now only allowing static url containing CSV. 