### PR TITLE
fix #866 switch db/Makefile to wget --timeout instead of relying on timeout cmd

### DIFF
--- a/db/Makefile
+++ b/db/Makefile
@@ -32,7 +32,7 @@ dmrmarc2.tmp: dmrmarc.tmp
 	awk -F, -f insert_nick.awk <$< >$@
 	
 dmrmarc.tmp:
-	timeout 120 wget --no-check-certificate --wait=3 'https://dmr-marc.net/static/users.csv' -O $@
+	wget --timeout=120 --no-check-certificate --wait=3 'https://dmr-marc.net/static/users.csv' -O $@
 
 reflector.tmp:
 	curl $(CURL_FLAGS) 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@


### PR DESCRIPTION
fixes #866 switch db/Makefile to wget --timeout instead of relying on timeout cmd. 