### PR TITLE
dmr-marc -> radioid.net for updatedb

### DIFF
--- a/db/Makefile
+++ b/db/Makefile
@@ -32,7 +32,7 @@ dmrmarc2.tmp: dmrmarc.tmp
 	awk -F, -f insert_nick.awk <$< >$@
 	
 dmrmarc.tmp:
-	wget --timeout=120 --no-check-certificate --wait=3 'https://dmr-marc.net/static/users.csv' -O $@
+	wget --timeout=120 --no-check-certificate --wait=3 'https://www.radioid.net/static/users.csv' -O $@
 
 reflector.tmp:
 	curl $(CURL_FLAGS) 'http://registry.dstar.su/reflector.db' | perl -pe '$$_ = "" if ( $$. == 1 ); s#@#,#; s#@.*#,,,,,,#' >$@
@@ -41,7 +41,7 @@ special.tmp:
 	python2 get_special_IDs.py
 	
 users.json:
-	curl $(CURL_FLAGS) 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=json&header=0' >$@
+	curl $(CURL_FLAGS) 'https://www.radioid.net/static/users.json' >$@
 
 repeaters.json:
 	curl $(CURL_FLAGS) 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=repeaters&format=json&header=0' >$@


### PR DESCRIPTION
The dmr-marc databases are no longer available on dmr-marc.net and dmr-marc.net points to radioid.net as the new home.  

Also added in some logging to get_dmrmarc_json.py. It looks like there are bigger issues with the script, but they are no longer being masked with a catch-all except/pass.