### PR TITLE
Print usage in md380-tool if parameters used wrong

### DIFF
--- a/md380_tool.py
+++ b/md380_tool.py
@@ -802,6 +802,8 @@ def main():
             elif sys.argv[1] == 'screenshot':
                 dfu = init_dfu()
                 screenshot(dfu)
+            else:
+                usage()
 
         elif len(sys.argv) == 3:
             if sys.argv[1] == 'flashdump':
@@ -840,6 +842,8 @@ def main():
             elif sys.argv[1] == 'screenshot':
                 dfu = init_dfu()
                 screenshot(dfu, sys.argv[2])
+            else:
+                usage()
 
         elif len(sys.argv) == 4:
             if sys.argv[1] == 'spiflashwrite':
@@ -854,6 +858,8 @@ def main():
                 print("Dumping memory from %s." % sys.argv[3])
                 dfu = init_dfu()
                 dump(dfu, sys.argv[2], sys.argv[3])
+            else:
+                usage()
 
         else:
             usage()


### PR DESCRIPTION
`md380-tool` succeeds silently if called with an invalid command (eg. `md380-tool flaashdump foo.bin`) or a valid command missing arguments (`md380-tool flashdump`). Print usage then to inform the user that nothing happened and they should call it properly.