### PR TITLE
fix compiler warning of implicit declaration

### DIFF
--- a/applet/src/usb.c
+++ b/applet/src/usb.c
@@ -34,6 +34,7 @@
 #include "keyb.h"
 #include "stm32f4xx_flash.h"
 
+void reboot_into_bootloader();
 
 int usb_upld_hook(void* iface, char *packet, int bRequest, int something){
   /* This hooks the USB Device Firmware Update upload function,


### PR DESCRIPTION
Fixes:

src/usb.c:330:8: error: implicit declaration of function 'reboot_into_bootloader' [-Werror=implicit-function-declaration]