### PR TITLE
Remove extraneous call to usage() on spiflashwrite

### DIFF
--- a/md380_tool.py
+++ b/md380_tool.py
@@ -871,7 +871,7 @@ def main():
                     spiflashwrite(dfu, sys.argv[2], adr)
                 else:
                     print("address too low")
-            if sys.argv[1] == 'dump':
+            elif sys.argv[1] == 'dump':
                 print("Dumping memory from %s." % sys.argv[3])
                 dfu = init_dfu()
                 dump(dfu, sys.argv[2], sys.argv[3])


### PR DESCRIPTION
# Reason for this Pull Request
It removes anextraneous call to `usage()` on `spiflashwrite` from within `md380_tool.py` as shown below.
## Expected behaviour
When calling `make flashdb` I would expect to see this behaviour:
```
$ make flashdb
"/Applications/Xcode.app/Contents/Developer/usr/bin/make" -C db stripped.csv
make[1]: `stripped.csv' is up to date.
wc -c < db/stripped.csv > user.bin
cat db/stripped.csv >> user.bin
./md380-tool spiflashwrite user.bin 0x100000
SPI Flash ID: ef 40 18
W25Q128FV 16MByte
erase 3657956 bytes @ 0x100000
flashing 3657956 bytes @ 0x100000
reboot radio now
johnmurray at diamond in ~/stuff/radio-stuff/md380tools
```
## Actual behaviour
When calling `make flashdb` I see this behaviour because there is there is an extraneous call to `usage()` from within `md380_tool.py`:
```
johnmurray at diamond in ~/stuff/radio-stuff/md380tools
$ make flashdb
"/Applications/Xcode.app/Contents/Developer/usr/bin/make" -C db stripped.csv
make[1]: `stripped.csv' is up to date.
wc -c < db/stripped.csv > user.bin
cat db/stripped.csv >> user.bin
./md380-tool spiflashwrite user.bin 0x100000
SPI Flash ID: ef 40 18
W25Q128FV 16MByte
erase 3657956 bytes @ 0x100000
flashing 3657956 bytes @ 0x100000
reboot radio now

Usage: md380-tool <command> <arguments>

Looks up the name by an ID number.
...
...
Copy users.csv to SPI flash:
    wc -c < db/users.csv > data ; cat db/users.csv >> data
    md380-tool spiflashwrite data 0x100000

johnmurray at diamond in ~/stuff/radio-stuff/md380tools
```
## Resolution
An `elif` statement has been incorrectly coded as an `if` statement in `md380_tool.py` as shown below.
```
$ git diff HEAD^
diff --git a/md380_tool.py b/md380_tool.py
index bc92cb4..917265c 100755
--- a/md380_tool.py
+++ b/md380_tool.py
@@ -871,7 +871,7 @@ def main():
                     spiflashwrite(dfu, sys.argv[2], adr)
                 else:
                     print("address too low")
-            if sys.argv[1] == 'dump':
+            elif sys.argv[1] == 'dump':
                 print("Dumping memory from %s." % sys.argv[3])
                 dfu = init_dfu()
                 dump(dfu, sys.argv[2], sys.argv[3])
johnmurray at diamond in ~/stuff/radio-stuff/md380tools
```