### PR TITLE
Added Ubuntu specific packages

### DIFF
--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -7,6 +7,12 @@
     sudo apt-get update
     sudo apt-get dist-upgrade
     sudo apt-get install git gcc-arm-none-eabi binutils-arm-none-eabi python-usb libnewlib-arm-none-eabi make curl
+    
+#### Ubuntu Bionic (18.04.1): ####
+
+    sudo apt-get update
+    sudo apt-get dist-upgrade
+    sudo apt-get install git gcc-arm-none-eabi binutils-arm-none-eabi python-usb libnewlib-arm-none-eabi make curl zip unzip
 
 For reverse engineering:
 


### PR DESCRIPTION
I had created a new Ubuntu 18.04.1 LTS build VM and ran into issues when the 'zip' and 'unzip' packages were not installed by default. I've modified this document to include it for any future users.