### PR TITLE
To avoid "ID unknown" message when userdb is over 7 Meg.

### DIFF
--- a/applet/src/usersdb.c
+++ b/applet/src/usersdb.c
@@ -123,7 +123,7 @@ static int find_dmr_user(char *outstr, int dmr_search, const char *data, int out
 
     // filesize @ 20160420 is 2279629 bytes
     //          @ 20170213 is 2604591 bytes
-    if (datasize == 0 || datasize > 7340031)  // 7 Meg sanity limit
+    if (datasize == 0 || datasize > 9437183)  // 9 Meg sanity limit
        return(0);
 
     const char *data_start = next_line_ptr(data);


### PR DESCRIPTION
Related to: #827  In that issue, the description should have said "5 Meg"  In this PR, it really is 7 Meg.   Now pushing up to 9 Megs.  (15 Megs will be the max we can go)