### PR TITLE
Website URL fix, md830.tools doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ md380tools@googlegroups.com. So feel free to put in your questions into it!
 
 A few of us are also on the #md380 IRC channel on Freenode.
 
-A helpful site is available at http://md380.tools/
+A helpful site is available at http://md380tools.org/
 
 There are also some related groups you may find interesting:
 - https://www.facebook.com/groups/KD4ZToolkit/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ md380tools@googlegroups.com. So feel free to put in your questions into it!
 
 A few of us are also on the #md380 IRC channel on Freenode.
 
-A helpful site is available at http://md380tools.org/
+A helpful site is available at http://md380.org/
 
 There are also some related groups you may find interesting:
 - https://www.facebook.com/groups/KD4ZToolkit/


### PR DESCRIPTION
The url in the readme was outdated, and goes to an ad ridden landing page with no content. This PR updates that url to the md380tools.org domain that has the expected content