### PR TITLE
TA: redraw rx screen

### DIFF
--- a/applet/src/etsi.c
+++ b/applet/src/etsi.c
@@ -7,6 +7,7 @@
 
 #include "etsi.h"
 #include "debug.h"
+#include "md380.h"
 #include "syslog.h"
 #include <string.h>
 
@@ -160,4 +161,11 @@ void decode_ta( lc_t *lc )
             PRINT("TA Unsupported format: %s", get_ta_type_str(taContext.format));
         }
     }
+
+    if (talkerAlias.length > 0) {
+      if( global_addl_config.userscsv > 1) {
+        gui_opmode1 |= 0x80; // redraw hack
+      }
+    }
+
 }


### PR DESCRIPTION
if display -> show calls is set to TA or TA&DB, redraw rx screen after TA is decoded

idk if there is better way to fix this, calling draw_rx_screen() did not work for me..

cc @shawnchain 