### PR TITLE
Quick tool to execute arbitrary code on the MD380.  Needs more testin…

### DIFF
--- a/applet/src/tooldfu.h
+++ b/applet/src/tooldfu.h
@@ -27,6 +27,8 @@ fetching the raw buffer.
 #define TDFU_C5000_WRITEREG 0x10 //u8 reg, u8 val
 #define TDFU_C5000_READREG  0x11 //u8 register
 
+//Dangerous commands.
+#define TDFU_EXEC  0x20
 
 //Graphics Commands
 #define TDFU_PRINT 0x80 //(u8 x, u8 y, wchar_t str[])

--- a/applet/src/usb.c
+++ b/applet/src/usb.c
@@ -242,9 +242,13 @@ int usb_dnld_hook(){
     case TDFU_SYSLOG:
       syslog_dump_dmesg();
       break;
+
+    case TDFU_EXEC:
+      execshellcode(md380_packet+5);
+      break;
     
     default:
-      printf("Unhandled DFU packet type 0x%02x.\n",md380_packet[0]);
+      printf("Unhandled DFU packet type 0x%02x.\n", md380_packet[0]);
     }
     
     md380_thingy2[0]=0;
@@ -261,6 +265,23 @@ int usb_dnld_hook(){
      */
     return usb_dnld_handle();
   }
+}
+
+//! This executes shellcode from the provided address.
+int execshellcode(int (*functionPtr)(int)){
+  uint32_t res;
+  uint8_t* bytes=(uint8_t*) (((int) functionPtr)-1);
+  
+  printf("Executing shellcode from 0x%08x: \n\n",
+	 (int) functionPtr);
+
+  for(int i=0;i<32;i++)
+    printf("%02x ",bytes[i]);
+
+  
+  res=functionPtr(0xdeadbeef);
+  printf("\nres=0x%08x\n",res);
+  return res;
 }
 
 

--- a/md380_tool.py
+++ b/md380_tool.py
@@ -97,6 +97,24 @@ class Tool(DFU):
             return False
         return True
 
+    def parsehex(self, string):
+        """Parses hex bytes."""
+        parsed="";
+        for word in string.split():
+            parsed=parsed+chr(int(word,16));
+        return parsed;
+    def execute(self, shellcode):
+        """Executes a short chunk of Thumb2 shellcode on 32-bit aligned memory."""
+        cmd = 0x20 #TDFU_EXEC
+
+        #Pad to a full word.
+        cmdstr = (chr(cmd)+"   "+shellcode);
+        
+        self._device.ctrl_transfer(0x21, Request.DNLOAD, 1, 0,
+                                   cmdstr)
+        self.get_status()
+        time.sleep(0.1)
+        
     def peek(self, adr, size):
         """Returns so many bytes from an address."""
         self.set_address(adr)
@@ -353,7 +371,7 @@ class Tool(DFU):
 
 def dmesg(dfu):
     """Prints the dmesg log from main memory."""
-    # dfu.drawtext("Dumping dmesg",160,50);
+    #dfu.drawtext("Dumping dmesg",160,50);
     print(dfu.getdmesg())
 
 
@@ -654,6 +672,9 @@ Dumps all the inbound and outbound text messages.
 Dumps all the keys.
     md380-tool keys
 
+Execute a chunk of shellcode as a function.
+    md380-tool exec "70 47"
+
 Prints the SPI Flash Type.
     md380-tool spiflashid
 Dump all of flash memory.
@@ -761,7 +782,11 @@ def main():
                 dfu = init_dfu()
                 dfu.custom(int(sys.argv[2], 16))
                 dmesg(dfu)
-
+            elif sys.argv[1] == 'exec' or sys.argv[1] == 'execute' :
+                dfu = init_dfu()
+                dfu.execute(dfu.parsehex(sys.argv[2]));
+                #dmesg(dfu);
+                
         elif len(sys.argv) == 4:
             if sys.argv[1] == 'spiflashwrite':
                 filename = sys.argv[2]


### PR DESCRIPTION
./md380-dfu read mycodeplug.img
printf '\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF' | dd conv=notrunc of=mycodeplug.img bs=1 seek=$((0x20a0))
./md380-dfu write mycodeplug.img
