### PR TITLE
Add fcommon to CFLAGS to build with new arm-none-eabi-gcc

### DIFF
--- a/applet/Makefile
+++ b/applet/Makefile
@@ -91,6 +91,7 @@ CFLAGS += -std=gnu99 -g -O2 -Wall -T$(LINKSCRIPT)
 CFLAGS += -mlittle-endian -mthumb -mcpu=cortex-m4 -mthumb-interwork
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 CFLAGS += -fshort-wchar
+CFLAGS += -fcommon
 ifdef MKLISTING
 CFLAGS += -Wa,-a=$(@:.o=.lst)
 endif


### PR DESCRIPTION
Thanks to @halfmanhalftaco's fix in #922 this is building again. I only tested on Arch not sure if there are regressions on older versions. 