### PR TITLE
Push sanity check on contact data to 15 Meg maximum.

### DIFF
--- a/applet/src/usersdb.c
+++ b/applet/src/usersdb.c
@@ -123,7 +123,7 @@ static int find_dmr_user(char *outstr, int dmr_search, const char *data, int out
 
     // filesize @ 20160420 is 2279629 bytes
     //          @ 20170213 is 2604591 bytes
-    if (datasize == 0 || datasize > 9437183)  // 9 Meg sanity limit
+    if (datasize == 0 || datasize >15728639)  // 15 Meg sanity limit
        return(0);
 
     const char *data_start = next_line_ptr(data);


### PR DESCRIPTION
Maximum useable space for contact data is 15 Megs. Above that, we are into the OEM zone and bad things are likely happening elsewhere anyway.   Enhanced contact data scripting has tipped the stripped.csv above the current limit of 9 Megs.  Swinging for the fence, one last time.