### PR TITLE
Fix md380-emu segfault on RPi kernels > 5.4.x

### DIFF
--- a/emulator/ambe.c
+++ b/emulator/ambe.c
@@ -24,6 +24,10 @@ void decode_amb_file(char *infilename,
 
   int ambfd=STDIN_FILENO;
   int wavfd=STDOUT_FILENO;
+
+  if(mprotect((void*)0x800c000, 0xf2c00, PROT_EXEC)){
+	fprintf(stderr, "Failed to set firmware section executable, vocoding will probably fail.\n");
+  }
     
   if (infilename)
     ambfd=open(infilename,0);


### PR DESCRIPTION
On RPi kernels > 5.4 md380-emu segfaults because the .firmware section in memory is not marked as executable, instead only 'WA' as shown by readelf -S md380-emu.  This didn't seem to matter until after kernel 5.4.  Valgrind shows that the segfault is due to lack of execute permissions in that region.  This patch calls mprotect() to set the region executable, which solves this problem on RaspiOS and Pistar versions that all used to work until the kernel was updated from 5.4 -> 5.10.  For reference, the 2021-01-11 raspiOS image with the 5.4 kernel still works with no changes.  After upgrading to latest kernel, it segfaults.