### PR TITLE
Add support for the indexed users db format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,16 @@ user.bin: db/stripped.csv
 	wc -c < db/stripped.csv > user.bin
 	cat db/stripped.csv >> user.bin
 
+indexeduser.bin: db/stripped.csv
+	./lineardb_to_indexeddb.py db/stripped.csv indexeduser.bin
+
 .PHONY: flashdb
 flashdb: user.bin
 	./md380-tool spiflashwrite user.bin 0x100000
+
+.PHONY: flashidb
+flashidb: indexeduser.bin
+	./md380-tool spiflashwrite indexeduser.bin 0x100000
 
 .PHONY: release
 release:

--- a/README-INDEXEDDB.md
+++ b/README-INDEXEDDB.md
@@ -1,0 +1,275 @@
+# MD380 Indexed User DB Description #
+This file contains a description of an alternative indexed format
+for storing the users database inside an md380 radio.  Instead of
+a linear string format, the indexed format is organized in a tree
+structure, such that every string associated with the user (callsign,
+name, city, state, and country) is stored only once and referenced by
+each of the users to which it applies.  The motivation for producing
+a new format is to reduce the space required for the users database.
+This format typically uses less than half the space used by the
+standard format.
+
+The first bytes of the header cause firmware that doesn't support
+the indexed format so see the database as an empty database in
+the original database format.  This avoids crashes.
+
+The code to handle the indexed format co-exists with the existing
+code that handles the original database format.  This will permit
+a possibly lengthy transition period before the number of DMR users
+exceeds the capacity of the original database format.
+
+The database is composed of 3 sections: 1) header section, 2) index
+table section, and 3) node data section.  Unless otherwise stated,
+offsets are measured from the beginning of the header section.
+
+## Header Section ##
+The header section has 3 parts, each 3 bytes in length: 1) a magic
+number with value 0x300a01, 2) the number of user entries in in the
+index table section, and 3) the size of the entire database in bytes.
+The last entry is useful for a utility that needs to extract the
+database from the radio.
+
+Note that the magic number's first two characters are ascii '0'
+and '\n'.  Older firmware expecting the original linear database
+format will see that as an empty database.
+
+
+          Header +------------------------------+
+                 |         Magic number         |
+                 +------------------------------+
+                 |      # of user entries       |
+                 +------------------------------+
+                 |       Size of database       |
+                 +------------------------------+
+
+  
+## Index Table Section ##
+The index table section contains an array of entries, one for each DMR
+user in the database, sorted by DMR ID. Each entry has two 3-byte parts:
+1) the user's DMR ID, and 2) the offset of the user node.
+
+All offsets are stored most-significant byte first (big endian).
+
+     Index Table +------------------------------+
+                 |           DMR ID 0           |
+                 +------------------------------+
+                 |    Offset of user node 0     |
+                 +------------------------------+
+                 |           DMR ID 1           |
+                 +------------------------------+
+                 |    Offset of user node 1     |
+                 +------------------------------+
+                 |           DMR ID 2           |
+                 +------------------------------+
+                 |    Offset of user node 2     |
+                 +------------------------------+
+                               .
+                               .
+                               .
+                 +------------------------------+
+                 |           DMR ID N-1         |
+                 +------------------------------+
+                 |   Offset of user node N-1    |
+                 +------------------------------+
+
+  
+## Node Data Section ##
+The node data section contains a pool of user data nodes.  The nodes
+are in arbitrary order, though they are arranged in a tree by offsets
+(serving as pointers) contained in other nodes.  Note that the country
+nodes are stored at the beginning of the node data section.  This permits
+them to be referenced by a 2-byte offset contained in a state node.
+
+       Node Data +------------------------------+
+                 |    Beginning of node data    |
+                 +------------------------------+
+                               .
+                               .
+                               .
+                 +------------------------------+
+                 |     End of user database     |
+                 +------------------------------+
+
+
+## User Node ##
+A user node contains the user's callsign and several optional fields.
+The optional fields are:
+
+  A 3-byte offset to the user's name node,
+
+  A 3-byte offset to the user's nickname node.
+
+  A 3-byte offset to the user's city node.
+
+  A 3-byte offset to the user's state node.
+
+  A 2-byte offset to the user's counry node.
+
+The callsign character string is preceded by one or two bytes.
+The first byte contains 5 flag bits and a 3-bit callsign length.
+If the callsign length exceeds 7 characters, the 3-bit length
+field is set to 0 and an additional byte is added containing
+the callsign length.  The flag bits are set to indicate that
+the corresponding node exists in this node or one of the nodes
+pointed to by one of the offsets contained in this node.
+
+Note that only the first of city node offset, state node offset,
+or country node offset will be contained in the user node, since
+each of these nodes contains the offset of the following node types.
+
+        User Node +-------------------+
+                  |      flag/len     |
+                  +-------------------+
+                  |  alen (optional)  |
+                  +-------------------+
+                  |   callsign char 0 |
+                  +-------------------+
+                  |   callsign char 1 |
+                  +-------------------+
+                  |   callsign char 2 |
+                  +-------------------+
+                            .
+                            .
+                            .
+                  +-------------------+
+                  |callsign char len-1|
+                  +------------------------------------+
+                  |   Offset of name node (optional)   |
+                  +------------------------------------+
+                  | Offset of nickname node (optional) |
+                  +------------------------------------+
+                  |   Offset of city node (optional)   |
+                  +------------------------------------+
+                  |   Offset of state node (optional)  |
+                  +------------------------------------+
+                  | Offset of country node* (optional) |
+                  +------------------------------------+
+
+        * The offset of the country node is a 2-byte field whose
+          value is relative to the start of the node data section.
+
+ 
+## Name Node ##
+A name node contains the user's name.  The len field
+contains the length of the following user name string.
+
+        Name Node +-------------------+
+                  |        len        |
+                  +-------------------+
+                  |    name char 0    |
+                  +-------------------+
+                  |    name char 1    |
+                  +-------------------+
+                  |    name char 2    |
+                  +-------------------+
+                            .
+                            .
+                            .
+                  +-------------------+
+                  |  name char len-1  |
+                  +-------------------+
+ 
+
+## Nickname Node ##
+A nickname node contains the user's nickname.  The len field
+contains the length of the following user nickname string.
+
+    Nickname Node +-------------------+
+                  |        len        |
+                  +-------------------+
+                  |  nickname char 0  |
+                  +-------------------+
+                  |  nickname char 1  |
+                  +-------------------+
+                  |  nickname char 2  |
+                  +-------------------+
+                            .
+                            .
+                            .
+                  +-------------------+
+                  |nickname char len-1|
+                  +-------------------+
+
+
+## City Node ##
+A city node contains the user's city name.  It also contains: an
+optional 3-byte offset of the user's state node and an optional
+2-byte offset of the user's country node.  The len field contains
+the length of the following city string.
+
+Note that if the city node contains a state node offset it will
+not contain a country node offset.
+
+        City Node +---------------+
+                  |      len      |
+                  +---------------+
+                  |  city char 0  |
+                  +---------------+
+                  |  city char 1  |
+                  +---------------+
+                  |  city char 2  |
+                  +---------------+
+                          .
+                          .
+                          .
+                  +---------------+
+                  |city char len-1|
+                  +----------------------------------+
+                  | Offset of state node (optional)  |
+                  +----------------------------------+
+                  |Offset of country node* (optional)|
+                  +----------------------------------+
+ 
+        * The offset of the country node is a 2-byte field whose
+          value is relative to the start of the node data section.
+  
+
+## State Node ##
+A state node contains the user's state name.  It also optionally
+contains a 2-byte offset of the user's country node.  The len field
+contains the length of the following state string.
+
+       State Node +----------------+
+                  |      len       |
+                  +----------------+
+                  |  state char 0  |
+                  +----------------+
+                  |  state char 1  |
+                  +----------------+
+                  |  state char 2  |
+                  +----------------+
+                          .
+                          .
+                          .
+                  +----------------+
+                  |state char len-1|
+                  +----------------------------------+
+                  |Offset of country node* (optional)|
+                  +----------------------------------+
+ 
+        * The offset of the country node is a 2-byte field whose
+          value is relative to the start of the node data section.
+  
+  
+## Country Node ##
+A country node contains the country name for a user.  The len
+field contains the length of the following country name string.
+Country nodes are stored at the beginning of the node data section.
+This permits them to be referenced by a 2-byte offset in a state
+node.
+
+     Country Node +------------------+
+                  |       len        |
+                  +------------------+
+                  |  country char 0  |
+                  +------------------+
+                  |  country char 1  |
+                  +------------------+
+                  |  country char 2  |
+                  +------------------+
+                           .
+                           .
+                           .
+                  +------------------+
+                  |country char len-1|
+                  +------------------+

--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ make updatedb flashdb
 with `make updatedb`, otherwise it will continue using any already-existing 
 `users.csv` file when running `make flashdb`.)
 
+### Flash updated indexed users database for linux based installations ###
+
+The indexed users database format only works with very recent md380tools firmware.
+
+Turn radio normally on to begin database loading with USB cable
+
+For European users:
+```
+make updatedb_eur flashidb
+```
+Note: for European users it is probably illegal to use the other method for updating, due to privacy laws.
+(This is no legal advice, please consult your lawyer to be sure.)
+
+For the rest of the world:
+```
+make updatedb flashidb
+```
+
+(The `users.csv` file located in the db directory must be refreshed this way, 
+with `make updatedb`, otherwise it will continue using any already-existing 
+`users.csv` file when running `make flashdb`.)
+
 ## Convenient Usage: ##
 
 Anything with `md380-tool` requires a recent version of our patched

--- a/applet/src/usersdb.c
+++ b/applet/src/usersdb.c
@@ -23,6 +23,7 @@ static char * getdata(char * dest, const char *  src, int count) {
 #include "md380.h"
 #include "usersdb.h"
 #include "spiflash.h"
+#include "printf.h"
 
 /* All user database data is accessed through this function.
  * This makes it easier to adapt to different kinds of sources.
@@ -158,6 +159,224 @@ static int find_dmr_user(char *outstr, int dmr_search, const char *data, int out
 //    return pos;
 //}
 
+#define USER_BASE_ADDR     0x100000
+#define MAGIC_OFFSET       0
+#define USER_COUNT_OFFSET  3
+#define INDEX_TABLE_OFFSET 9
+#define INDEX_ENTRY_SIZE   6
+#define MAGIC_VALUE        (('0' << 16) | ('\n' << 8) | 1)
+
+#define NAME_FLAG          (1 << 7)
+#define NICKNAME_FLAG      (1 << 6)
+#define CITY_FLAG          (1 << 5)
+#define STATE_FLAG         (1 << 4)
+#define COUNTRY_FLAG       (1 << 3)
+
+char *getdata_offset(char *dest, int offset, int count) {
+    getdata(dest, (const char *)(USER_BASE_ADDR + offset), count);
+    return dest;
+}
+
+int get3(int offset)
+{
+    unsigned char buf[3];
+    int val;
+
+    getdata_offset((char *)buf, offset, sizeof buf);
+
+    val = buf[0] << 16;
+    val |= buf[1] << 8;
+    val |= buf[2];
+
+    return val;
+}
+
+int get3_incr(int *offsetp)
+{
+    int result;
+
+    result = get3(*offsetp);
+    (*offsetp) += 3;
+
+    return result;
+}
+
+int get2_incr(int *offsetp)
+{
+    unsigned char buf[2];
+    int val;
+
+    getdata_offset((char *)buf, *offsetp, sizeof buf);
+    (*offsetp) += sizeof buf;
+
+    val = buf[0] << 8;
+    val |= buf[1];
+
+    return val;
+}
+
+int get1_incr(int *offsetp)
+{
+    unsigned char buf[1];
+
+    getdata_offset((char *)buf, *offsetp, sizeof buf);
+    (*offsetp) += sizeof buf;
+
+    return buf[0];
+}
+
+char *getstr_incr(char **destp, int *offsetp, int len, char *dest_end) {
+    int maxlen = dest_end - *destp;;
+    char *result = dest_end;
+
+    maxlen--;
+    if (maxlen > 0) {
+        if (maxlen > len) {
+            maxlen = len;
+        }
+        getdata_offset(*destp, *offsetp, maxlen);
+        result = *destp;
+        *destp += maxlen;
+        *(*destp)++ = 0;
+    }
+
+    (*offsetp) += len;
+
+    return result;
+}
+
+void get_indexed_user(user_t *up, int offset, int user_count)
+{
+    int dmrid;
+    int callsign_offset;
+    int name_offset;
+    int nickname_offset;
+    int city_offset;
+    int state_offset;
+    int country_offset;
+    char *ubufp;
+    char *ubuf_end;
+    int flag;
+    int len;
+    int *state_offsetp;
+    int *country_offsetp;
+
+    dmrid = get3_incr(&offset);
+    callsign_offset = get3(offset);
+
+    ubufp = &up->buffer[0];
+    ubuf_end = &up->buffer[sizeof up->buffer - 1];
+
+    up->id = ubufp;
+    sprintf(up->id, "%d", dmrid);
+    ubufp += strlen(up->id) + 1;
+
+    len = get1_incr(&callsign_offset);
+    flag = len & (NAME_FLAG | NICKNAME_FLAG | CITY_FLAG | STATE_FLAG | COUNTRY_FLAG);
+    len = len & ~(NAME_FLAG | NICKNAME_FLAG | CITY_FLAG | STATE_FLAG | COUNTRY_FLAG);
+
+    if (len == 0) {
+        len = get1_incr(&callsign_offset);
+    }
+
+    up->callsign = getstr_incr(&ubufp, &callsign_offset, len, ubuf_end);
+
+    up->name = ubuf_end;
+    up->firstname = ubuf_end;
+    up->place = ubuf_end;
+    up->state = ubuf_end;
+    up->country = ubuf_end;
+
+    if (flag & NAME_FLAG) {
+        name_offset = get3_incr(&callsign_offset);
+        len = get1_incr(&name_offset);
+        up->name = getstr_incr(&ubufp, &name_offset, len, ubuf_end);
+    }
+
+    if (flag & NICKNAME_FLAG) {
+        nickname_offset = get3_incr(&callsign_offset);
+        len = get1_incr(&nickname_offset);
+        up->firstname = getstr_incr(&ubufp, &nickname_offset, len, ubuf_end);
+    }
+
+    state_offsetp = &callsign_offset;
+    country_offsetp = &callsign_offset;
+
+    if (flag & CITY_FLAG) {
+        city_offset = get3_incr(&callsign_offset);
+        len = get1_incr(&city_offset);
+        up->place = getstr_incr(&ubufp, &city_offset, len, ubuf_end);
+
+        if (flag & STATE_FLAG) {
+            state_offsetp = &city_offset;
+        } else if (flag & COUNTRY_FLAG) {
+            country_offsetp = &city_offset;
+        }
+    }
+
+    if (flag & STATE_FLAG) {
+        state_offset = get3_incr(state_offsetp);
+        len = get1_incr(&state_offset);
+        up->state = getstr_incr(&ubufp, &state_offset, len, ubuf_end);
+
+        if (flag & COUNTRY_FLAG) {
+            country_offsetp = &state_offset;
+        }
+    }
+
+    if (flag & COUNTRY_FLAG) {
+        country_offset = get2_incr(country_offsetp) + INDEX_TABLE_OFFSET + user_count * INDEX_ENTRY_SIZE;
+        len = get1_incr(&country_offset);
+        up->country = getstr_incr(&ubufp, &country_offset, len, ubuf_end);
+    }
+
+    *ubuf_end = 0;
+}
+
+/* returns 0 on failure */
+int find_dmr_user_indexed(user_t *up, int dmrid)
+{
+    int magic;
+    int first;
+    int last;
+    int middle;
+    int middleid;
+    int user_count;
+
+    magic = get3(MAGIC_OFFSET);
+    if (magic != MAGIC_VALUE) {
+        return 0;
+    } 
+    user_count = get3(USER_COUNT_OFFSET);
+
+    first = 0;
+    last = user_count - 1;
+
+    /* stifle warnings about middle and middleid being uninitialized */
+    middle = 0;
+    middleid = 0;
+
+    while (first <= last) {
+        middle = (first + last) / 2;
+        middleid = get3(middle * INDEX_ENTRY_SIZE + INDEX_TABLE_OFFSET);
+        if (middleid < dmrid) {
+            first = middle + 1;
+        } else if (middleid == dmrid) {
+            break;
+        } else {
+            last = middle - 1;
+        }
+    }
+
+    if (middleid != dmrid) {
+        return 0;
+    }
+
+    get_indexed_user(up, middle * INDEX_ENTRY_SIZE + INDEX_TABLE_OFFSET, user_count);
+
+    return 1;
+}
+
 void usr_splitbuffer(user_t *up)
 {
     char *cp = up->buffer ;
@@ -208,6 +427,9 @@ void usr_splitbuffer(user_t *up)
 int usr_find_by_dmrid( user_t *up, int dmrid )
 {
     if( !find_dmr_user(up->buffer, dmrid, (void *) 0x100000, BSIZE) ) {
+        if ( find_dmr_user_indexed(up, dmrid) ) {
+            return 1;
+        }
         // safeguard
         up->buffer[0] = '?' ;
         up->buffer[1] = 0 ;

--- a/lineardb_to_indexeddb.py
+++ b/lineardb_to_indexeddb.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Dale Farnsworth
+#
+# This file converts a canonical md380 users database file
+# into an indexed database file containing the same information,
+# but uilizing about half of the space.
+
+from __future__ import print_function
+
+import sys
+import os
+
+class LinearDB(object):
+
+    def __init__(self, filename):
+        """Loads the database."""
+        import csv
+
+        self.users = {}
+
+        try:
+            if filename is None:
+                filename = sys.path[0] + '/user.bin'
+            with open(filename, 'rb') as csvfile:
+                reader = csv.reader(csvfile)
+                for row in reader:
+                    if len(row) > 1:
+                        self.users[int(row[0])] = row
+        except:
+            print("Can't open %s" % filename)
+
+
+            # print("WARNING: Unable to load user.bin.")
+            pass
+
+class IndexedDB(object):
+    MAGIC         = 0x300a01
+    MAGICOFFSET   = 0
+    HEADERSIZE    = 9
+    INDEXSIZE     = 6
+
+    NAMEFLAG      = 1 << 7
+    NICKNAMEFLAG  = 1 << 6
+    CITYFLAG      = 1 << 5
+    STATEFLAG     = 1 << 4
+    COUNTRYFLAG   = 1 << 3
+
+    SHORTCALLSIGN = 7
+
+    def __init__(self, length):
+        self.length = length
+        self.buffer = bytearray(15*1024*1024)
+        self.offset = self.HEADERSIZE
+        self.node_pool_offset = self.HEADERSIZE + length * self.INDEXSIZE
+        self.end_offset = self.node_pool_offset
+        self.string_dict = {}
+        self.callsign_dict = {}
+        self.city_dict = {}
+        self.state_dict = {}
+
+    def set_offset(self, offset):
+        self.offset = offset
+
+    def get_offset(self):
+        return self.offset
+
+    def set_endoffset(self, offset):
+        self.end_offset = offset
+
+    def get_end_offset(self):
+        return self.end_offset
+
+    def id_int(self, id_str):
+        return int(id_str)
+
+    def put3(self, value):
+        self.buffer[self.offset] = (value >> 16) & 0xff
+        self.buffer[self.offset+1] = (value >> 8) & 0xff
+        self.buffer[self.offset+2] = value & 0xff
+        self.offset += 3
+
+    def append_offset(self, offset):
+        self.buffer[self.end_offset] = (offset >> 16) & 0xff
+        self.buffer[self.end_offset+1] = (offset >> 8) & 0xff
+        self.buffer[self.end_offset+2] = offset & 0xff
+        self.end_offset += 3
+
+    def append_flag(self, flag):
+        self.buffer[self.end_offset] = flag
+        self.end_offset += 1
+
+    def append_2byte_offset(self, offset):
+        self.buffer[self.end_offset] = (offset >> 8) & 0xff
+        self.buffer[self.end_offset+1] = offset & 0xff
+        self.end_offset += 2
+
+    def append_string_with_flag(self, str, flag):
+        self.buffer[self.end_offset] = flag | len(str)
+        self.end_offset += 1
+
+        bytes = str.encode("utf-8")
+        for i, byte in enumerate(bytes):
+            self.buffer[self.end_offset+i] = byte
+
+        self.end_offset += len(str)
+
+    def append_string(self, str):
+        self.append_string_with_flag(str, 0)
+
+    def append_string_node(self, string):
+        if string not in self.string_dict:
+            self.string_dict[string] = self.end_offset
+            self.append_string(string)
+
+        return self.string_dict[string]
+
+    def append_name_node(self, name):
+        return self.append_string_node(name)
+
+    def append_nickname_node(self, nickname):
+        return self.append_string_node(nickname)
+
+    def append_city_node(self, city, state, country):
+        str = ",".join([city, state, country])
+        if str not in self.city_dict:
+            if len(state) > 0:
+                state_offset = self.append_state_node(state, country)
+            elif len(country) > 0:
+                country_offset = self.append_country_node(country)
+
+            self.city_dict[str] = self.end_offset
+
+            self.append_string(city)
+
+            if len(state) > 0:
+                self.append_offset(state_offset)
+            elif len(country) > 0:
+                self.append_2byte_offset(country_offset)
+
+        return self.city_dict[str]
+
+    def append_state_node(self, state, country):
+        str = ",".join([state, country])
+
+        if str not in self.state_dict:
+            if len(country) > 0:
+                country_offset = self.append_country_node(country)
+
+            self.state_dict[str] = self.end_offset
+
+            self.append_string(state)
+
+            if len(country) > 0:
+                self.append_2byte_offset(country_offset)
+        
+        return self.state_dict[str]
+
+
+    def append_country_node(self, country):
+        return self.append_string_node(country) - self.node_pool_offset
+
+    def append_callsign_node(self, callsign, name, nickname, city, state, country):
+        str = ",".join([callsign, name, nickname, city, state, country])
+        if str not in self.callsign_dict:
+            flag = 0
+
+            if len(name) > 0:
+                flag |= self.NAMEFLAG
+                name_offset = self.append_name_node(name)
+
+            if len(nickname) > 0:
+                flag |= self.NICKNAMEFLAG
+                nickname_offset = self.append_nickname_node(nickname)
+
+            if len(city) > 0:
+                flag |= self.CITYFLAG
+                city_offset = self.append_city_node(city, state, country)
+
+            if len(state) > 0:
+                flag |= self.STATEFLAG
+                state_offset = self.append_state_node(state, country)
+
+            if len(country) > 0:
+                flag |= self.COUNTRYFLAG
+                country_offset = self.append_country_node(country)
+
+            self.callsign_dict[str] = self.end_offset
+
+            if len(callsign) == 0 or len(callsign) > self.SHORTCALLSIGN:
+                self.append_flag(flag)
+                flag = 0
+
+            self.append_string_with_flag(callsign, flag)
+
+            if len(name) > 0:
+                self.append_offset(name_offset)
+
+            if len(nickname) > 0:
+                self.append_offset(nickname_offset)
+
+            if len(city) > 0:
+                self.append_offset(city_offset)
+            elif len(state) > 0:
+                self.append_offset(state_offset)
+            elif len(country) > 0:
+                self.append_2byte_offset(country_offset)
+
+        return self.callsign_dict[str]
+
+    def update_header(self):
+        self.offset = self.MAGICOFFSET
+        self.put3(self.MAGIC)
+        self.put3(self.length)
+        self.put3(self.end_offset)
+
+    def add_user(self, id, callsign, name, nickname, city, state, country):
+        self.put3(id)
+        self.put3(self.append_callsign_node(callsign, name, nickname, city, state, country))
+
+    def write_file(self, filename):
+        self.update_header()
+        f = open(filename, "w+b")
+        f.write(self.buffer[:self.end_offset])
+
+def linearDB_to_indexedDB(linear_filename, indexed_filename):
+    linear = LinearDB(linear_filename)
+    indexed = IndexedDB(len(linear.users))
+
+    for id, user in sorted(linear.users.items()):
+        (idstr, callsign, name, city, state, nickname, country) = user
+        if len(country) > 0:
+            indexed.append_country_node(country)
+
+    for id, user in sorted(linear.users.items()):
+        (idstr, callsign, name, city, state, nickname, country) = user
+        indexed.add_user(id, callsign, name, nickname, city, state, country)
+
+    indexed.write_file(indexed_filename)
+
+def usage(msg):
+    global progname
+
+    if len(msg) > 0:
+        print(msg, file=sys.stderr)
+    print("Usage: %s [OPTION]... <linearDBfile> <indexedDBfile>" % progname, file=sys.stderr)
+    print("\t-n, --nicknames", file=sys.stderr)
+    print("\t\tInclude nicknames in database", file=sys.stderr)
+    sys.exit(1)
+
+def main():
+    global progname
+    progname = sys.argv[0]
+    args = sys.argv[1:]
+
+    if len(args) != 2:
+        usage("")
+
+    infilename = args[0]
+    outfilename = args[1]
+
+    linearDB_to_indexedDB(infilename, outfilename)
+
+main()


### PR DESCRIPTION
The indexed format is a tree-structured database.  Each
unique string is stored only once in the db and referenced through
pointers by each dmr ID entry that uses that string.

The new format uses about half the space of the standard
md380 userdb format.