### PR TITLE
Fix md380-emu encoder crash on modern RPi kernels

### DIFF
--- a/emulator/ambe.c
+++ b/emulator/ambe.c
@@ -148,6 +148,10 @@ void encode_wav_file(char *infilename,
   short *inbuf1 = (short*) &wav_inbuffer1;
   short *ambe   = (short*) &ambe_outbuffer;
 
+  if(mprotect((void*)0x800c000, 0xf2c00, PROT_EXEC)){
+	fprintf(stderr, "Failed to set firmware section executable, vocoding will probably fail.\n");
+  }
+
   write(ambfd,".amb",4); // write dsd header
 
   short inbuf[160];


### PR DESCRIPTION
This is a port of the https://github.com/travisgoodspeed/md380tools/pull/932 work to the 'encoding' function.

Without this patch:

```
pi@store:~/md380tools/emulator $ gdb --args ./md380-emu -e -i test.wav -o test.ambe
GNU gdb (Raspbian 8.2.1-2) 8.2.1
...
Reading symbols from ./md380-emu...done.
(gdb) r
Starting program: /home/pi/md380tools/emulator/md380-emu -e -i test.wav -o test.ambe
Encoding 8kHz Raw Mono Signed test.wav to AMBE test.ambe.

Program received signal SIGSEGV, Segmentation fault.
0x08050d90 in _binary____firmware_unwrapped_D002_032_img_start ()
```

After this patch:

```
$ ./md380-emu -e -i test.wav -o test.ambe
Encoding 8kHz Raw Mono Signed test.wav to AMBE test.ambe.
Done with AMBE test.
```

System details:

```
$ uname -a
Linux store 5.10.63-v7l+ #1459 SMP Wed Oct 6 16:41:57 BST 2021 armv7l GNU/Linux

$ cat /proc/cpuinfo  # RPi 4
processor	: 0
model name	: ARMv7 Processor rev 3 (v7l)
BogoMIPS	: 108.00
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3
...
```

Thanks!