### PR TITLE
Reverted to old PyUSB in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> {}; {
+with import <nixpkgs> { }; {
   md380toolsEnv = stdenv.mkDerivation {
     name = "md380toolsEnv";
     buildInputs = [
@@ -8,11 +8,22 @@ with import <nixpkgs> {}; {
       libusb1
       perl
       python27
-      python27Packages.pyusb
+      (pkgs.python27Packages.buildPythonPackage rec {
+        pname = "pyusb";
+        version = "1.1.0"; # the last Python 2 version
+        src = pkgs.python27Packages.fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-1p7WS/8OIQLaEbP0lWclaGeFO4YReGiWcaFj0whlwpg=";
+        };
+        doCheck = false;
+        propagatedBuildInputs = [
+          pkgs.python27Packages.setuptools_scm
+        ];
+      })
       unzip
       wget
       which
     ];
-    LD_LIBRARY_PATH="${libusb1.out}/lib";
+    LD_LIBRARY_PATH = "${libusb1.out}/lib";
   };
 }


### PR DESCRIPTION
nix-shell `default.nix` was failing, complaining about python incompatibility, per #945 .

I've downgraded PyUSB to something that works with Python 2.7.