### PR TITLE
Downgraded default.nix to allow build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ with import <nixpkgs> { }; {
     name = "md380toolsEnv";
     buildInputs = [
       curl
-      gcc-arm-embedded
+      gcc-arm-embedded-9
       gnumake
       libusb1
       perl

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> {}; {
+with import <nixpkgs> { }; {
   md380toolsEnv = stdenv.mkDerivation {
     name = "md380toolsEnv";
     buildInputs = [
@@ -8,11 +8,22 @@ with import <nixpkgs> {}; {
       libusb1
       perl
       python27
-      python27Packages.pyusb
+      (pkgs.python27Packages.buildPythonPackage rec {
+        pname = "pyusb";
+        version = "1.1.0"; # the last Python 2 version
+        src = pkgs.python27Packages.fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-1p7WS/8OIQLaEbP0lWclaGeFO4YReGiWcaFj0whlwpg=";
+        };
+        doCheck = false;
+        propagatedBuildInputs = [
+          pkgs.python27Packages.setuptools_scm
+        ];
+      })
       unzip
       wget
       which
     ];
-    LD_LIBRARY_PATH="${libusb1.out}/lib";
+    LD_LIBRARY_PATH = "${libusb1.out}/lib";
   };
 }


### PR DESCRIPTION
In master, currently, running `nix-shell default.nix` produces an error on installing pyusb, for the latest version doesn't work with Python2. See #945 for details.

Further, attempting to compile produces similar issues to #922 .

I've downgraded these packages, and used this `nix-shell` to successfully install the patched firmware on my md380.