### PR TITLE
get_special_IDs.py handle master servers with empty ID lists

### DIFF
--- a/db/get_special_IDs.py
+++ b/db/get_special_IDs.py
@@ -60,8 +60,11 @@ for idx, item in enumerate(data):
         except socket.error:
             print("Socket Error...\n")
         else:
+            # Handle servers which answer with an empty file
+            if not content:
+                print("List with special IDs empty!\n")
             # Handle servers which answer with HTTP 200 but give file not found
-            if "DOCTYPE" in content:
+            elif "DOCTYPE" in content:
                 print("List with special IDs not found!\n")
             else:
                 print(content)


### PR DESCRIPTION
The BM master for 2682 replies with an empty special_IDs.csv.
This changes handles that case.